### PR TITLE
[Async] Enforce minimum response buffer sizes.

### DIFF
--- a/BBB_ccip_async/hw/rtl/ccip_async_shim.sv
+++ b/BBB_ccip_async/hw/rtl/ccip_async_shim.sv
@@ -195,6 +195,12 @@ module ccip_async_shim
    // the AFU responding to almost full.
    localparam C0_REQ_CREDIT_LIMIT = (2 ** C0RX_DEPTH_RADIX) -
                                     CCIP_TX_ALMOST_FULL_THRESHOLD * 8;
+   generate
+       if (C0_REQ_CREDIT_LIMIT <= 0) begin
+           always $display("C0RX_DEPTH_RADIX is too small");
+           PARAMETER_ERROR dummy();
+       end
+   endgenerate
 
    always @(posedge afu_clk) begin
       afu_rx_q.c0TxAlmFull <= c0tx_cnt[C0TX_DEPTH_RADIX-1] ||
@@ -283,11 +289,16 @@ module ccip_async_shim
    end
 
    // Maximum number of line requests outstanding is the size of the buffer
-   // minus the number of requests that may arrive after asserting almost full.
-   // Multiply the threshold by 2 in order to leave room for some delay in
-   // the AFU responding to almost full.
+   // minus the number of requests that may arrive after asserting almost full,
+   // with some wiggle room added for message latency.
    localparam C1_REQ_CREDIT_LIMIT = (2 ** C1RX_DEPTH_RADIX) -
-                                    CCIP_TX_ALMOST_FULL_THRESHOLD * 2;
+                                    CCIP_TX_ALMOST_FULL_THRESHOLD * 8;
+   generate
+       if (C1_REQ_CREDIT_LIMIT <= 0) begin
+           always $display("C1RX_DEPTH_RADIX is too small");
+           PARAMETER_ERROR dummy();
+       end
+   endgenerate
 
    always @(posedge afu_clk) begin
       afu_rx_q.c1TxAlmFull <= c1tx_cnt[C1TX_DEPTH_RADIX-1] ||

--- a/BBB_ccip_async/hw/rtl/ccip_async_shim.sv
+++ b/BBB_ccip_async/hw/rtl/ccip_async_shim.sv
@@ -197,8 +197,14 @@ module ccip_async_shim
                                     CCIP_TX_ALMOST_FULL_THRESHOLD * 8;
    generate
        if (C0_REQ_CREDIT_LIMIT <= 0) begin
-           always $display("C0RX_DEPTH_RADIX is too small");
+           //
+           // Error: C0RX_DEPTH_RADIX is too small, given the number of
+           //        requests that may be in flight after almost full is
+           //        asserted!
+           //
+           // Force a compile-time failure...
            PARAMETER_ERROR dummy();
+           always $display("C0RX_DEPTH_RADIX is too small");
        end
    endgenerate
 
@@ -295,8 +301,14 @@ module ccip_async_shim
                                     CCIP_TX_ALMOST_FULL_THRESHOLD * 8;
    generate
        if (C1_REQ_CREDIT_LIMIT <= 0) begin
-           always $display("C1RX_DEPTH_RADIX is too small");
+           //
+           // Error: C1RX_DEPTH_RADIX is too small, given the number of
+           //        requests that may be in flight after almost full is
+           //        asserted!
+           //
+           // Force a compile-time failure...
            PARAMETER_ERROR dummy();
+           always $display("C1RX_DEPTH_RADIX is too small");
        end
    endgenerate
 


### PR DESCRIPTION
If the response buffer is too small then the tracker counting in-flight requests
computes incorrect thresholds.  Add compile-time error checks to enforce
minimum buffer sizes.  Also made minimum c1Rx buffer size larger to account
for multi-beat write responses.