### PR TITLE
Fix a race in MPF's store buffer when PWrite is enabled

### DIFF
--- a/BBB_cci_mpf/hw/par/qsf_cci_mpf_PAR_files.qsf
+++ b/BBB_cci_mpf/hw/par/qsf_cci_mpf_PAR_files.qsf
@@ -61,6 +61,7 @@ set_global_assignment -name SYSTEMVERILOG_FILE $CCI_MPF_SRC/hw/rtl/cci-mpf-prims
 set_global_assignment -name SYSTEMVERILOG_FILE $CCI_MPF_SRC/hw/rtl/cci-mpf-prims/cci_mpf_prim_repl_lru_pseudo.sv
 set_global_assignment -name SYSTEMVERILOG_FILE $CCI_MPF_SRC/hw/rtl/cci-mpf-prims/cci_mpf_prim_repl_random.sv
 set_global_assignment -name SYSTEMVERILOG_FILE $CCI_MPF_SRC/hw/rtl/cci-mpf-prims/cci_mpf_prim_rob.sv
+set_global_assignment -name SYSTEMVERILOG_FILE $CCI_MPF_SRC/hw/rtl/cci-mpf-prims/cci_mpf_prim_semaphore_cam.sv
 set_global_assignment -name SYSTEMVERILOG_FILE $CCI_MPF_SRC/hw/rtl/cci-mpf-prims/cci_mpf_prim_track_active_reqs.sv
 set_global_assignment -name SYSTEMVERILOG_FILE $CCI_MPF_SRC/hw/rtl/cci-mpf-prims/cci_mpf_prim_track_multi_write.sv
 

--- a/BBB_cci_mpf/hw/rtl/cci-mpf-prims/cci_mpf_prim_semaphore_cam.sv
+++ b/BBB_cci_mpf/hw/rtl/cci-mpf-prims/cci_mpf_prim_semaphore_cam.sv
@@ -1,0 +1,146 @@
+//
+// Copyright (c) 2018, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// Neither the name of the Intel Corporation nor the names of its contributors
+// may be used to endorse or promote products derived from this software
+// without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+
+//
+// Semaphore: test whether an index is set in a set. The implemenation here uses
+// a CAM, so the number of live entries must be relatively small.
+//
+// Slots in the CAM are allocated round-robin. Code that uses this module
+// must make N_ENTRIES large enough that an entry is cleared before the
+// round-robin pointer reaches the entry again. This works well for tasks
+// such as tracking values in a FIFO.
+//
+
+module cci_mpf_prim_semaphore_cam
+  #(
+    parameter N_ENTRIES = 0,
+    parameter N_IDX_BITS = 0
+    )
+   (
+    input  logic clk,
+    input  logic reset,
+    output logic rdy,
+
+    input  logic set_en,
+    input  logic [N_IDX_BITS-1 : 0] set_idx,
+    input  logic clear_en,
+    input  logic [N_IDX_BITS-1 : 0] clear_idx,
+
+    input  logic [N_IDX_BITS-1 : 0] test_idx,
+    output logic is_set
+    );
+
+    typedef logic [$clog2(N_ENTRIES)-1 : 0] t_bucket_idx;
+    typedef logic [N_IDX_BITS-1 : 0] t_idx;
+
+    assign rdy = 1'b1;
+
+    logic bucket_valid[0 : N_ENTRIES-1];
+    t_idx bucket_value[0 : N_ENTRIES-1];
+
+    t_bucket_idx next_idx;
+
+    //
+    // Test for a value
+    //
+    logic [N_ENTRIES-1 : 0] bucket_match;
+
+    genvar b;
+    generate
+        for (b = 0; b < N_ENTRIES; b = b + 1)
+        begin : match
+            assign bucket_match[b] = bucket_valid[b] && (bucket_value[b] == test_idx);
+        end
+    endgenerate
+
+    assign is_set = (|(bucket_match));
+
+    //
+    // Update buckets
+    //
+    generate
+        for (b = 0; b < N_ENTRIES; b = b + 1)
+        begin : upd
+            always_ff @(posedge clk)
+            begin
+                if (clear_en && (bucket_value[b] == clear_idx))
+                begin
+                    bucket_valid[b] <= 1'b0;
+                end
+
+                // Buckets are allocated round robin
+                if (set_en && (next_idx == t_bucket_idx'(b)))
+                begin
+                    bucket_valid[b] <= 1'b1;
+                    bucket_value[b] <= set_idx;
+                end
+
+                if (reset)
+                begin
+                    bucket_valid[b] <= 1'b0;
+                end
+            end
+        end
+    endgenerate
+
+    // Use buckets round-robin. The client is expected never to have more than
+    // N_ENTRIES in flight and these entries must be retired in order.
+    // There is an assertion at the bottom of the module that checks this
+    // in simulation.
+    always_ff @(posedge clk)
+    begin
+        if (set_en)
+        begin
+            next_idx <= (next_idx == t_bucket_idx'(N_ENTRIES-1) ?
+                         t_bucket_idx'(0) :
+                         next_idx + t_bucket_idx'(1));
+        end
+
+        if (reset)
+        begin
+            next_idx <= t_bucket_idx'(0);
+        end
+    end
+    
+    always_ff @(negedge clk)
+    begin
+        if (reset)
+        begin
+            // Nothing
+        end
+        else if (set_en)
+        begin
+            assert (! bucket_valid[next_idx]) else
+                $fatal(2, "cci_mpf_prim_semaphore_cam: Setting entry before previous instance was cleared!");
+        end
+    end
+
+endmodule // cci_mpf_prim_semaphore_cam

--- a/BBB_cci_mpf/hw/rtl/cci-mpf-shims/cci_mpf_shim_edge/cci_mpf_shim_edge.vh
+++ b/BBB_cci_mpf/hw/rtl/cci-mpf-shims/cci_mpf_shim_edge/cci_mpf_shim_edge.vh
@@ -44,6 +44,8 @@ interface cci_mpf_shim_edge_if
     //
     logic wen;
     logic [$clog2(N_WRITE_HEAP_ENTRIES)-1 : 0] widx;
+    logic wsop;
+    logic weop;
     t_cci_clNum wclnum;
     t_cci_clData wdata;
     logic wAlmFull;
@@ -59,6 +61,8 @@ interface cci_mpf_shim_edge_if
        (
         output wen,
         output widx,
+        output wsop,
+        output weop,
         output wclnum,
         output wdata,
         input  wAlmFull,
@@ -71,6 +75,8 @@ interface cci_mpf_shim_edge_if
        (
         input  wen,
         input  widx,
+        input  wsop,
+        input  weop,
         input  wclnum,
         input  wdata,
         output wAlmFull,

--- a/BBB_cci_mpf/hw/rtl/cci-mpf-shims/cci_mpf_shim_edge/cci_mpf_shim_edge_afu.sv
+++ b/BBB_cci_mpf/hw/rtl/cci-mpf-shims/cci_mpf_shim_edge/cci_mpf_shim_edge_afu.sv
@@ -190,7 +190,7 @@ module cci_mpf_shim_edge_afu
         end
     endgenerate
 
-endmodule
+endmodule // cci_mpf_shim_edge_afu
 
 
 //
@@ -289,10 +289,34 @@ module cci_mpf_shim_edge_afu_wr_data
     //
     // The heap holding write data is in the FIU edge module.
     //
-    assign fiu_edge.wen = cci_mpf_c1TxIsWriteReq(afu.c1Tx);
-    assign fiu_edge.widx = wr_heap_enq_idx;
-    assign fiu_edge.wclnum = wr_heap_enq_clNum;
-    assign fiu_edge.wdata = afu.c1Tx.data;
+    always_comb
+    begin
+        fiu_edge.wen = cci_mpf_c1TxIsWriteReq(afu.c1Tx);
+        fiu_edge.widx = wr_heap_enq_idx;
+        fiu_edge.wclnum = wr_heap_enq_clNum;
+        fiu_edge.wdata = afu.c1Tx.data;
+
+        if (! fiu_edge.wen)
+        begin
+            fiu_edge.wsop = 1'b0;
+            fiu_edge.weop = 1'b0;
+        end
+        else
+        begin
+            fiu_edge.wsop = afu.c1Tx.hdr.base.sop;
+            // Compute EOP
+            if (afu.c1Tx.hdr.base.sop)
+            begin
+                // Single beat packet?
+                fiu_edge.weop = (afu.c1Tx.hdr.base.cl_len == eCL_LEN_1);
+            end
+            else
+            begin
+                // End of multi-beat packet?
+                fiu_edge.weop = (wr_heap_enq_clNum == c1tx_sop_hdr.base.cl_len);
+            end
+        end
+    end
 
     //
     // Forward partial write requests to the partial write emulator.
@@ -515,4 +539,4 @@ module cci_mpf_shim_edge_afu_wr_data
         end
     end
 
-endmodule // cci_mpf_shim_edge_afu
+endmodule // cci_mpf_shim_edge_afu_wr_data

--- a/BBB_cci_mpf/hw/rtl/cci_mpf.sv
+++ b/BBB_cci_mpf/hw/rtl/cci_mpf.sv
@@ -243,6 +243,12 @@ module cci_mpf
         )
       pwrite();
 
+    cci_mpf_shim_pwrite_lock_if
+      #(
+        .N_WRITE_HEAP_ENTRIES(N_WRITE_HEAP_ENTRIES)
+        )
+      pwrite_lock();
+
     cci_mpf_shim_vtp_pt_walk_if pt_walk();
 
     cci_mpf_shim_edge_fiu
@@ -264,7 +270,8 @@ module cci_mpf
         .afu(stgm2_mpf_fiu),
         .afu_edge(edge_if),
         .pt_walk,
-        .pwrite
+        .pwrite,
+        .pwrite_lock
         );
 
 
@@ -368,6 +375,8 @@ module cci_mpf
         .mpf_csrs,
         .edge_if,
         .pwrite,
+        .pwrite_afu(pwrite),
+        .pwrite_lock,
         .vtp_svc(vtp_svc_ports[0:1])
         );
 

--- a/BBB_cci_mpf/hw/rtl/cci_mpf_pipe_std.sv
+++ b/BBB_cci_mpf/hw/rtl/cci_mpf_pipe_std.sv
@@ -93,7 +93,9 @@ module cci_mpf_pipe_std
     cci_mpf_shim_edge_if.edge_afu edge_if,
 
     // Connect MPF's AFU edge module to its partial write emulation module
-    cci_mpf_shim_pwrite_if pwrite,
+    cci_mpf_shim_pwrite_if.pwrite pwrite,
+    cci_mpf_shim_pwrite_if.pwrite_edge_afu pwrite_afu,
+    cci_mpf_shim_pwrite_lock_if.pwrite pwrite_lock,
 
     // VTP translation service ports.  One port for each request channel.
     cci_mpf_shim_vtp_svc_if.client vtp_svc[0 : 1]
@@ -157,7 +159,8 @@ module cci_mpf_pipe_std
                 .clk,
                 .fiu(stgp1_fiu_eop),
                 .afu(stgp2_pwrite),
-                .pwrite,
+                .pwrite(pwrite),
+                .pwrite_lock(pwrite_lock),
                 .events(mpf_csrs)
                 );
         end
@@ -395,7 +398,7 @@ module cci_mpf_pipe_std
         .fiu(stgp7_fiu_rsp_order),
         .afu,
         .fiu_edge(edge_if),
-        .pwrite
+        .pwrite(pwrite_afu)
         );
 
 endmodule // cci_mpf_pipe_std

--- a/BBB_cci_mpf/hw/sim/cci_mpf_sim_addenda.txt
+++ b/BBB_cci_mpf/hw/sim/cci_mpf_sim_addenda.txt
@@ -61,6 +61,7 @@
 ../rtl/cci-mpf-prims/cci_mpf_prim_repl_lru_pseudo.sv
 ../rtl/cci-mpf-prims/cci_mpf_prim_repl_random.sv
 ../rtl/cci-mpf-prims/cci_mpf_prim_rob.sv
+../rtl/cci-mpf-prims/cci_mpf_prim_semaphore_cam.sv
 ../rtl/cci-mpf-prims/cci_mpf_prim_track_active_reqs.sv
 ../rtl/cci-mpf-prims/cci_mpf_prim_track_multi_write.sv
 ../rtl/cci-mpf-shims/cci_mpf_shim_buffer_afu.sv

--- a/BBB_cci_mpf/test/test-mpf/test_random/sw/test_random.cpp
+++ b/BBB_cci_mpf/test/test-mpf/test_random/sw/test_random.cpp
@@ -85,7 +85,7 @@ int TEST_RANDOM::test()
     // Allocate memory for control
     auto dsm_buf_handle = this->allocBuffer(getpagesize());
     auto dsm = reinterpret_cast<volatile uint64_t*>(dsm_buf_handle->c_type());
-    uint64_t dsm_pa = dsm_buf_handle->iova();
+    uint64_t dsm_pa = dsm_buf_handle->io_address();
     assert(NULL != dsm);
     memset((void*)dsm, 0, getpagesize());
 


### PR DESCRIPTION
When MPF's partial write support is enabled, there is contention for MPF's write data
buffer between AFU store requests and updates from the partial writes read-modify-write.
This can delay write data long enough that the write control fires first, using stale
data. New code here locks write data buffer slots until the update completes.
