### PR TITLE
Update dualport RAM primitives in MPF for Quartus 18

### DIFF
--- a/BBB_cci_mpf/hw/rtl/cci-mpf-prims/cci_mpf_prim_fifo_bram.sv
+++ b/BBB_cci_mpf/hw/rtl/cci-mpf-prims/cci_mpf_prim_fifo_bram.sv
@@ -34,6 +34,8 @@
 //   THRESHOLD or fewer slots are free, stored in block RAM.
 //
 
+`include "cci_mpf_platform.vh"
+
 module cci_mpf_prim_fifo_bram
   #(
     parameter N_DATA_BITS = 32,
@@ -77,6 +79,9 @@ module cci_mpf_prim_fifo_bram
 
     scfifo
       #(
+`ifdef PLATFORM_INTENDED_DEVICE_FAMILY
+        .intended_device_family(`PLATFORM_INTENDED_DEVICE_FAMILY),
+`endif
         .lpm_numwords(N_ENTRIES),
         .lpm_showahead("OFF"),
         .lpm_type("scfifo"),

--- a/BBB_cci_mpf/hw/rtl/cci-mpf-prims/cci_mpf_prim_ram_dualport.sv
+++ b/BBB_cci_mpf/hw/rtl/cci-mpf-prims/cci_mpf_prim_ram_dualport.sv
@@ -35,6 +35,8 @@
 // by the other port is don't care.
 //
 
+`include "cci_mpf_platform.vh"
+
 module cci_mpf_prim_ram_dualport
   #(
     parameter N_ENTRIES = 32,
@@ -84,6 +86,9 @@ module cci_mpf_prim_ram_dualport
 
     altsyncram
       #(
+`ifdef PLATFORM_INTENDED_DEVICE_FAMILY
+        .intended_device_family(`PLATFORM_INTENDED_DEVICE_FAMILY),
+`endif
         .operation_mode("BIDIR_DUAL_PORT"),
         .width_a(N_DATA_BITS),
         .widthad_a($clog2(N_ENTRIES)),

--- a/BBB_cci_mpf/hw/rtl/cci-mpf-prims/cci_mpf_prim_ram_dualport.sv
+++ b/BBB_cci_mpf/hw/rtl/cci-mpf-prims/cci_mpf_prim_ram_dualport.sv
@@ -30,9 +30,13 @@
 //
 
 //
-// Dual port Block RAM.  When write is enabled on a port the rdata response
-// on the same port is the new data.  The rdata for the same address written
-// by the other port is don't care.
+// Dual port Block RAM.
+//
+// ***
+// *** Separate clocks may be specified for the two ports only when the
+// *** read during write mode is DONT_CARE.  Otherwise, clk0 is used and
+// *** clk1 is ignored.
+// ***
 //
 
 `include "cci_mpf_platform.vh"
@@ -44,8 +48,18 @@ module cci_mpf_prim_ram_dualport
     // Number of extra stages of output register buffering to add
     parameter N_OUTPUT_REG_STAGES = 0,
 
-    // Other options are "OLD_DATA" and "NEW_DATA"
+    // Operation mode, either "BIDIR_DUAL_PORT" or "DUAL_PORT".
+    // For DUAL_PORT configure only writes on port a and reads
+    // on port b.  This mode can be useful since M20K RAM does
+    // not allow 512 x 32 or 512 x 40 modes in bidirectional mode.
+    parameter OPERATION_MODE = "BIDIR_DUAL_PORT",
+
+    // Other options are "OLD_DATA" and "NEW_DATA".
     parameter READ_DURING_WRITE_MODE_MIXED_PORTS = "DONT_CARE",
+
+    // Default clock for port 1. This value must be CLOCK0 when
+    // READ_DURING_WRITE_MODE_MIXED_PORTS is something other than DONT_CARE.
+    parameter PORT1_CLOCK = "CLOCK1",
 
     // Default returns new data for reads on same port as a write.
     // (No NBE read means return X in masked bytes, which we don't support
@@ -80,62 +94,94 @@ module cci_mpf_prim_ram_dualport
     localparam OUTDATA_REGISTERED0 = (N_OUTPUT_REG_STAGES == 0) ? "UNREGISTERED" :
                                                                   "CLOCK0";
     localparam OUTDATA_REGISTERED1 = (N_OUTPUT_REG_STAGES == 0) ? "UNREGISTERED" :
-                                                                  "CLOCK1";
+                                                                  PORT1_CLOCK;
     localparam OUTDATA_IDX = (N_OUTPUT_REG_STAGES == 0) ? 0 : 1;
 
-
-    altsyncram
-      #(
 `ifdef PLATFORM_INTENDED_DEVICE_FAMILY
-        .intended_device_family(`PLATFORM_INTENDED_DEVICE_FAMILY),
+    localparam PLATFORM_INTENDED_DEVICE_FAMILY = `PLATFORM_INTENDED_DEVICE_FAMILY;
+`else
+    localparam PLATFORM_INTENDED_DEVICE_FAMILY = "Stratix";
 `endif
-        .operation_mode("BIDIR_DUAL_PORT"),
-        .width_a(N_DATA_BITS),
-        .widthad_a($clog2(N_ENTRIES)),
-        .numwords_a(N_ENTRIES),
-        .width_b(N_DATA_BITS),
-        .widthad_b($clog2(N_ENTRIES)),
-        .numwords_b(N_ENTRIES),
-        .outdata_reg_a(OUTDATA_REGISTERED0),
-        .rdcontrol_reg_b("CLOCK1"),
-        .address_reg_b("CLOCK1"),
-        .outdata_reg_b(OUTDATA_REGISTERED1),
-        .read_during_write_mode_mixed_ports(READ_DURING_WRITE_MODE_MIXED_PORTS),
-        .read_during_write_mode_port_a(READ_DURING_WRITE_MODE_PORT_A),
-        .read_during_write_mode_port_b(READ_DURING_WRITE_MODE_PORT_B)
-        )
-      data
-       (
-        .clock0(clk0),
-        .clock1(clk1),
 
-        .wren_a(wen0),
-        .address_a(addr0),
-        .data_a(wdata0),
-        .q_a(mem_rd0[OUTDATA_IDX]),
+    initial
+    begin
+        assert ((READ_DURING_WRITE_MODE_MIXED_PORTS == "DONT_CARE") ||
+                (PORT1_CLOCK == "CLOCK0")) else
+            $fatal(2, "PORT1_CLOCK is %s but must be CLOCK0 when READ_DURING_WRITE_MODE_MIXED_PORTS is DONT_CARE", PORT1_CLOCK);
+    end
 
-        .wren_b(wen1),
-        .address_b(addr1),
-        .data_b(wdata1),
-        .q_b(mem_rd1[OUTDATA_IDX]),
+    //
+    // Starting with version 18, Quartus is really picky about whether the clock1
+    // port is attached. We are forced to replicate the code, changing only the
+    // binding of the clock1 port. The macro avoids actual source replication.
+    //
 
-        // Legally unconnected ports -- get rid of lint errors
-        .rden_a(),
-        .rden_b(),
-        .clocken0(),
-        .clocken1(),
-        .clocken2(),
-        .clocken3(),
-        .aclr0(),
-        .aclr1(),
-        .byteena_a(),
-        .byteena_b(),
-        .addressstall_a(),
-        .addressstall_b(),
-        .eccstatus()
-        );
+    `define ALTSYNCRAM_DEF(CLK1_DEF) \
+      altsyncram \
+        #( \
+          .intended_device_family(PLATFORM_INTENDED_DEVICE_FAMILY), \
+          .operation_mode(OPERATION_MODE), \
+          .width_a(N_DATA_BITS), \
+          .widthad_a($clog2(N_ENTRIES)), \
+          .numwords_a(N_ENTRIES), \
+          .width_b(N_DATA_BITS), \
+          .widthad_b($clog2(N_ENTRIES)), \
+          .numwords_b(N_ENTRIES), \
+          .outdata_reg_a(OUTDATA_REGISTERED0), \
+          .rdcontrol_reg_b(PORT1_CLOCK), \
+          .address_reg_b(PORT1_CLOCK), \
+          .outdata_reg_b(OUTDATA_REGISTERED1), \
+          .indata_reg_b(PORT1_CLOCK), \
+          .wrcontrol_wraddress_reg_b(PORT1_CLOCK), \
+          .byteena_reg_b(PORT1_CLOCK), \
+          .read_during_write_mode_mixed_ports(READ_DURING_WRITE_MODE_MIXED_PORTS), \
+          .read_during_write_mode_port_a(READ_DURING_WRITE_MODE_PORT_A), \
+          .read_during_write_mode_port_b(READ_DURING_WRITE_MODE_PORT_B) \
+          ) \
+        data \
+         ( \
+          .clock0(clk0), \
+          ``CLK1_DEF, \
+          \
+          .wren_a(wen0), \
+          .address_a(addr0), \
+          .data_a(wdata0), \
+          .q_a(mem_rd0[OUTDATA_IDX]), \
+           \
+          .wren_b(wen1), \
+          .address_b(addr1), \
+          .data_b(wdata1), \
+          .q_b(mem_rd1[OUTDATA_IDX]), \
+           \
+          // Legally unconnected ports -- get rid of lint errors \
+          .rden_a(), \
+          .rden_b(), \
+          .clocken0(), \
+          .clocken1(), \
+          .clocken2(), \
+          .clocken3(), \
+          .aclr0(), \
+          .aclr1(), \
+          .byteena_a(), \
+          .byteena_b(), \
+          .addressstall_a(), \
+          .addressstall_b(), \
+          .eccstatus() \
+          );
+
+    generate
+        if (PORT1_CLOCK == "CLOCK1")
+        begin : c1
+            `ALTSYNCRAM_DEF(.clock1(clk1))
+        end
+        else
+        begin : c0
+            `ALTSYNCRAM_DEF(.clock1())
+        end
+    endgenerate
 
 
+    // Manage output buffering.
     genvar s;
     generate
         for (s = 1; s < N_OUTPUT_REG_STAGES; s = s + 1)
@@ -165,8 +211,18 @@ module cci_mpf_prim_ram_dualport_init
     // Number of extra stages of output register buffering to add
     parameter N_OUTPUT_REG_STAGES = 0,
 
+    // Operation mode, either "BIDIR_DUAL_PORT" or "DUAL_PORT".
+    // For DUAL_PORT configure only writes on port a and reads
+    // on port b.  This mode can be useful since M20K RAM does
+    // not allow 512 x 32 or 512 x 40 modes in bidirectional mode.
+    parameter OPERATION_MODE = "BIDIR_DUAL_PORT",
+
     // Other options are "OLD_DATA" and "NEW_DATA"
     parameter READ_DURING_WRITE_MODE_MIXED_PORTS = "DONT_CARE",
+
+    // Default clock for port 1. This value must be CLOCK0 when
+    // READ_DURING_WRITE_MODE_MIXED_PORTS is something other than DONT_CARE.
+    parameter PORT1_CLOCK = "CLOCK1",
 
     // Default returns new data for reads on same port as a write.
     // (No NBE read means return X in masked bytes.)
@@ -194,31 +250,33 @@ module cci_mpf_prim_ram_dualport_init
     output logic [N_DATA_BITS-1 : 0] rdata1
     );
 
-    logic [$clog2(N_ENTRIES)-1 : 0] addr1_local;
-    logic wen1_local;
-    logic [N_DATA_BITS-1 : 0] wdata1_local;
+    logic [$clog2(N_ENTRIES)-1 : 0] addr0_local;
+    logic wen0_local;
+    logic [N_DATA_BITS-1 : 0] wdata0_local;
 
     cci_mpf_prim_ram_dualport
       #(
         .N_ENTRIES(N_ENTRIES),
         .N_DATA_BITS(N_DATA_BITS),
         .N_OUTPUT_REG_STAGES(N_OUTPUT_REG_STAGES),
+        .OPERATION_MODE(OPERATION_MODE),
         .READ_DURING_WRITE_MODE_MIXED_PORTS(READ_DURING_WRITE_MODE_MIXED_PORTS),
+        .PORT1_CLOCK(PORT1_CLOCK),
         .READ_DURING_WRITE_MODE_PORT_A(READ_DURING_WRITE_MODE_PORT_A),
         .READ_DURING_WRITE_MODE_PORT_B(READ_DURING_WRITE_MODE_PORT_B)
         )
       ram
        (
         .clk0,
-        .addr0,
-        .wen0,
-        .wdata0,
+        .addr0(addr0_local),
+        .wen0(wen0_local),
+        .wdata0(wdata0_local),
         .rdata0,
 
         .clk1,
-        .addr1(addr1_local),
-        .wen1(wen1_local),
-        .wdata1(wdata1_local),
+        .addr1,
+        .wen1,
+        .wdata1,
         .rdata1
         );
 
@@ -227,23 +285,23 @@ module cci_mpf_prim_ram_dualport_init
     // Initialization loop
     //
 
-    logic [$clog2(N_ENTRIES)-1 : 0] addr1_init;
+    logic [$clog2(N_ENTRIES)-1 : 0] addr0_init;
 
-    assign addr1_local = rdy ? addr1 : addr1_init;
-    assign wen1_local = rdy ? wen1 : 1'b1;
-    assign wdata1_local = rdy ? wdata1 : INIT_VALUE;
+    assign addr0_local = rdy ? addr0 : addr0_init;
+    assign wen0_local = rdy ? wen0 : 1'b1;
+    assign wdata0_local = rdy ? wdata0 : INIT_VALUE;
 
-    always_ff @(posedge clk1)
+    always_ff @(posedge clk0)
     begin
         if (reset)
         begin
             rdy <= 1'b0;
-            addr1_init <= 0;
+            addr0_init <= 0;
         end
         else if (! rdy)
         begin
-            addr1_init <= addr1_init + 1;
-            rdy <= (addr1_init == (N_ENTRIES-1));
+            addr0_init <= addr0_init + 1;
+            rdy <= (addr0_init == (N_ENTRIES-1));
         end
     end
 

--- a/BBB_cci_mpf/hw/rtl/cci-mpf-prims/cci_mpf_prim_ram_dualport_byteena.sv
+++ b/BBB_cci_mpf/hw/rtl/cci-mpf-prims/cci_mpf_prim_ram_dualport_byteena.sv
@@ -121,7 +121,7 @@ module cci_mpf_prim_ram_dualport_byteena
     // binding of the clock1 port. The macro avoids actual source replication.
     //
 
-    `define ALTSYNCRAM_DEF(CLK1_DEF) \
+    `define ALTSYNCRAM_BYTEENA_DEF(CLK1_DEF) \
       altsyncram \
         #( \
           .intended_device_family(PLATFORM_INTENDED_DEVICE_FAMILY), \
@@ -180,11 +180,11 @@ module cci_mpf_prim_ram_dualport_byteena
     generate
         if (PORT1_CLOCK == "CLOCK1")
         begin : c1
-            `ALTSYNCRAM_DEF(.clock1(clk1))
+            `ALTSYNCRAM_BYTEENA_DEF(.clock1(clk1))
         end
         else
         begin : c0
-            `ALTSYNCRAM_DEF(.clock1())
+            `ALTSYNCRAM_BYTEENA_DEF(.clock1())
         end
     endgenerate
 

--- a/BBB_cci_mpf/hw/rtl/cci-mpf-prims/cci_mpf_prim_ram_simple.sv
+++ b/BBB_cci_mpf/hw/rtl/cci-mpf-prims/cci_mpf_prim_ram_simple.sv
@@ -33,6 +33,8 @@
 // Simple dual port Block RAM.
 //
 
+`include "cci_mpf_platform.vh"
+
 module cci_mpf_prim_ram_simple
   #(
     parameter N_ENTRIES = 32,
@@ -305,6 +307,9 @@ module cci_mpf_prim_ram_simple_base
 
     altsyncram
       #(
+`ifdef PLATFORM_INTENDED_DEVICE_FAMILY
+        .intended_device_family(`PLATFORM_INTENDED_DEVICE_FAMILY),
+`endif
         .operation_mode("DUAL_PORT"),
         .width_a(N_DATA_BITS),
         .widthad_a($clog2(N_ENTRIES)),

--- a/BBB_cci_mpf/hw/rtl/cci-mpf-prims/cci_mpf_prim_repl_lru_pseudo.sv
+++ b/BBB_cci_mpf/hw/rtl/cci-mpf-prims/cci_mpf_prim_repl_lru_pseudo.sv
@@ -145,7 +145,8 @@ module cci_mpf_prim_repl_lru_pseudo
     cci_mpf_prim_ram_dualport_init
       #(
         .N_ENTRIES(N_ENTRIES),
-        .N_DATA_BITS($bits(t_way_vec))
+        .N_DATA_BITS($bits(t_way_vec)),
+        .PORT1_CLOCK("CLOCK0")
         )
       lru_data
         (
@@ -153,11 +154,13 @@ module cci_mpf_prim_repl_lru_pseudo
          .rdy,
 
          .clk0(clk),
+         .clk1(),
+
          .addr0,
          .wen0,
          .wdata0,
          .rdata0,
-         .clk1(clk),
+
          .addr1,
          .wen1,
          .wdata1,

--- a/BBB_cci_mpf/hw/rtl/cci-mpf-shims/cci_mpf_shim_edge/cci_mpf_shim_edge_fiu.sv
+++ b/BBB_cci_mpf/hw/rtl/cci-mpf-shims/cci_mpf_shim_edge/cci_mpf_shim_edge_fiu.sv
@@ -210,12 +210,13 @@ module cci_mpf_shim_edge_fiu
         .N_ENTRIES(N_UNIQUE_WRITE_HEAP_ENTRIES),
         .N_DATA_BITS(CCI_CLDATA_WIDTH),
         .N_OUTPUT_REG_STAGES(1),
-        .OPERATION_MODE("DUAL_PORT")
+        .OPERATION_MODE("DUAL_PORT"),
+        .PORT1_CLOCK("CLOCK0")
         )
       wr_heap_data
        (
         .clk0(clk),
-        .clk1(clk),
+        .clk1(),
 
         .wen0(heap_wen),
         .byteena0(heap_wbyteena),

--- a/BBB_cci_mpf/test/test-mpf/test_cci_mpf_null/sw/test_cci_mpf_null.cpp
+++ b/BBB_cci_mpf/test/test-mpf/test_cci_mpf_null/sw/test_cci_mpf_null.cpp
@@ -79,7 +79,7 @@ int TEST_CCI_MPF_NULL::test()
     // Allocate memory for control
     auto dsm_buf_handle = this->allocBuffer(getpagesize());
     auto dsm = reinterpret_cast<volatile uint64_t*>(dsm_buf_handle->c_type());
-    uint64_t dsm_pa = dsm_buf_handle->iova();
+    uint64_t dsm_pa = dsm_buf_handle->io_address();
     assert(NULL != dsm);
     memset((void*)dsm, 0, getpagesize());
 
@@ -96,7 +96,7 @@ int TEST_CCI_MPF_NULL::test()
         const uint64_t n_bytes = 2 * 1024 * 1024;
         buf_handle[i] = this->allocBuffer(n_bytes);
         buf[i] = reinterpret_cast<volatile uint64_t*>(buf_handle[i]->c_type());
-        buf_pa[i] = buf_handle[i]->iova();
+        buf_pa[i] = buf_handle[i]->io_address();
         assert(NULL != buf[i]);
         memset((void*)buf[i], 0, n_bytes);
 

--- a/BBB_cci_mpf/test/test-mpf/test_random/hw/rtl/test_random.sv
+++ b/BBB_cci_mpf/test/test-mpf/test_random/hw/rtl/test_random.sv
@@ -925,6 +925,7 @@ module test_afu
         .N_ENTRIES(1 << N_CHECKED_ADDR_BITS),
         .N_DATA_BITS($bits(t_mem_tag)),
         .N_OUTPUT_REG_STAGES(2),
+        .OPERATION_MODE("DUAL_PORT"),
         .READ_DURING_WRITE_MODE_MIXED_PORTS("OLD_DATA")
         )
       chk_ram

--- a/BBB_cci_mpf/test/test-mpf/test_random/hw/rtl/test_random.sv
+++ b/BBB_cci_mpf/test/test-mpf/test_random/hw/rtl/test_random.sv
@@ -926,6 +926,7 @@ module test_afu
         .N_DATA_BITS($bits(t_mem_tag)),
         .N_OUTPUT_REG_STAGES(2),
         .OPERATION_MODE("DUAL_PORT"),
+        .PORT1_CLOCK("CLOCK0"),
         .READ_DURING_WRITE_MODE_MIXED_PORTS("OLD_DATA")
         )
       chk_ram

--- a/BBB_cci_mpf/test/test-mpf/test_random/sw/test_random.cpp
+++ b/BBB_cci_mpf/test/test-mpf/test_random/sw/test_random.cpp
@@ -85,7 +85,7 @@ int TEST_RANDOM::test()
     // Allocate memory for control
     auto dsm_buf_handle = this->allocBuffer(getpagesize());
     auto dsm = reinterpret_cast<volatile uint64_t*>(dsm_buf_handle->c_type());
-    uint64_t dsm_pa = dsm_buf_handle->iova();
+    uint64_t dsm_pa = dsm_buf_handle->io_address();
     assert(NULL != dsm);
     memset((void*)dsm, 0, getpagesize());
 


### PR DESCRIPTION
Quartus 18 is stricter about the way clocks are passed in to dual port block RAM when the cross-port read-during-write mode isn't DONT_CARE. Update the primitive to configure only a single clock when required.
