### PR TITLE
Add support for FPGA_BUF_PREALLOCATED in MPF/VTP buffer mapper.

### DIFF
--- a/BBB_cci_mpf/sw/include/opae/mpf/cxx/mpf_shared_buffer.h
+++ b/BBB_cci_mpf/sw/include/opae/mpf/cxx/mpf_shared_buffer.h
@@ -63,6 +63,17 @@ class mpf_shared_buffer : public opae::fpga::types::shared_buffer {
   static mpf_shared_buffer::ptr_t allocate(mpf_handle::ptr_t mpf_handle,
                                            size_t len);
 
+  /** shared_buffer factory method - attach an existing buffer.
+   * @param[in] handle The handle used to allocate the buffer.
+   * @param[in] base   The base of the pre-allocated memory.
+   * @param[in] len    The length in bytes of the requested buffer.
+   * @return A valid shared_buffer smart pointer on success, or an
+   * empty smart pointer on failure.
+   */
+  static mpf_shared_buffer::ptr_t attach(mpf_handle::ptr_t mpf_handle,
+                                         uint8_t *base,
+                                         size_t len);
+
  protected:
   mpf_shared_buffer(mpf_handle::ptr_t mpf_handle, size_t len,
                     uint8_t *virt, uint64_t iova);

--- a/BBB_cci_mpf/sw/src/libmpf/shim_vtp_pt.c
+++ b/BBB_cci_mpf/sw/src/libmpf/shim_vtp_pt.c
@@ -678,12 +678,13 @@ static void dumpPageTableVAtoPA(
                        nodeGetValue(wsid_table, idx));
 
                 uint32_t flags = nodeGetTranslatedAddrFlags(table, idx);
-                if (flags & (MPF_VTP_PT_FLAG_ALLOC_START |
-                             MPF_VTP_PT_FLAG_ALLOC_END))
+                if (flags & (MPF_VTP_PT_FLAG_MASK - MPF_VTP_PT_FLAG_TERMINAL))
                 {
                     printf(" [");
                     if (flags & MPF_VTP_PT_FLAG_ALLOC_START) printf(" START");
                     if (flags & MPF_VTP_PT_FLAG_ALLOC_END) printf(" END");
+                    if (flags & MPF_VTP_PT_FLAG_INVALID) printf(" INVALID");
+                    if (flags & MPF_VTP_PT_FLAG_PREALLOCATED) printf(" PREALLOC");
                     printf(" ]");
                 }
                 printf("\n");

--- a/BBB_cci_mpf/sw/src/libmpf/shim_vtp_pt.h
+++ b/BBB_cci_mpf/sw/src/libmpf/shim_vtp_pt.h
@@ -49,9 +49,14 @@ typedef enum
     // flags are used only in virtual to physical translation tables.
     MPF_VTP_PT_FLAG_ALLOC_START = 2,
     MPF_VTP_PT_FLAG_ALLOC_END = 4,
+    // Entry is invalid. This bit is used on the FPGA side to detect
+    // empty entries.
+    MPF_VTP_PT_FLAG_INVALID = 8,
+    // Buffer was pre-allocated outside MPF.
+    MPF_VTP_PT_FLAG_PREALLOCATED = 16,
 
     // All flags (mask)
-    MPF_VTP_PT_FLAG_MASK = 7
+    MPF_VTP_PT_FLAG_MASK = 31
 }
 mpf_vtp_pt_flag;
 

--- a/BBB_cci_mpf/test/test-mpf/base/sw/cci_test.h
+++ b/BBB_cci_mpf/test/test-mpf/base/sw/cci_test.h
@@ -81,6 +81,11 @@ class CCI_TEST
         return svc.allocBuffer(nBytes);
     }
 
+    fpga::types::shared_buffer::ptr_t attachBuffer(void* addr, size_t nBytes)
+    {
+        return svc.attachBuffer(addr, nBytes);
+    }
+
     void writeTestCSR(uint32_t idx, uint64_t v)
     {
         svc.write_csr64(8 * (TEST_CSR_BASE + idx), v);

--- a/BBB_cci_mpf/test/test-mpf/base/sw/opae_svc_wrapper.h
+++ b/BBB_cci_mpf/test/test-mpf/base/sw/opae_svc_wrapper.h
@@ -82,6 +82,12 @@ class OPAE_SVC_WRAPPER
     //
     fpga::types::shared_buffer::ptr_t allocBuffer(size_t nBytes);
 
+    //
+    // Like allocBuffer(), but attaches an existing buffer so it is
+    // available to the FPGA.
+    //
+    fpga::types::shared_buffer::ptr_t attachBuffer(void* addr, size_t nBytes);
+
     // Used during testing to force large or small pages
     void forceSmallPageAlloc(bool small)
     {


### PR DESCRIPTION
VTP can now translate addresses for buffers that are allocated outside of MPF
by passing buffers to mpfVtpPrepareBuffer().  The semantics are similar to
fpgaPrepareBuffer().  Pre-allocated buffers are removed from VTP when
mpfVtpReleaseBuffer() is called but remain allocated.