### PR TITLE
Fix two asserts to avoid simulation issues

### DIFF
--- a/BBB_cci_mpf/hw/rtl/cci-mpf-prims/cci_mpf_prim_fifo2.sv
+++ b/BBB_cci_mpf/hw/rtl/cci-mpf-prims/cci_mpf_prim_fifo2.sv
@@ -134,7 +134,7 @@ module cci_mpf_prim_fifo2_peek
         begin
             valid <= 2'b0;
         end
-        else
+        else if (reset == 1'b0)
         begin
             assert (! (enq_en && valid[0])) else
                 $fatal("cci_mpf_prim_fifo2: ENQ to full FIFO!");

--- a/BBB_cci_mpf/hw/rtl/cci-mpf-prims/cci_mpf_prim_rob.sv
+++ b/BBB_cci_mpf/hw/rtl/cci-mpf-prims/cci_mpf_prim_rob.sv
@@ -105,7 +105,7 @@ module cci_mpf_prim_rob
         begin
             newest <= 0;
         end
-        else
+        else if (reset == 1'b0)
         begin
             newest <= newest + t_idx'(alloc);
 


### PR DESCRIPTION
Sometimes we need to fanout the reset signal to pass timing. However,
when we add additional stages to the reset signal, at some stages the
value of the reset signal will be 'x', which may cause some unwanted
asserts in cci_mpf_prim_fifo2.sv and cci_mpf_prim_rob.sv. Modify two
lines to fix the problem.