### PR TITLE
Full MPF/VTP speculative load support

### DIFF
--- a/BBB_cci_mpf/hw/rtl/cci-if/ccip_if_funcs_pkg.sv
+++ b/BBB_cci_mpf/hw/rtl/cci-if/ccip_if_funcs_pkg.sv
@@ -2,6 +2,10 @@
 // Functions that operate on CCI-P data types.
 //
 
+`ifdef PLATFORM_IF_AVAIL
+`include "platform_if.vh"
+`endif
+
 package ccip_if_funcs_pkg;
 
     import ccip_if_pkg::*;

--- a/BBB_cci_mpf/hw/rtl/cci-if/ccip_if_funcs_pkg.sv
+++ b/BBB_cci_mpf/hw/rtl/cci-if/ccip_if_funcs_pkg.sv
@@ -84,6 +84,18 @@ package ccip_if_funcs_pkg;
         return r.rspValid && (r.hdr.resp_type == eRSP_RDLINE);
     endfunction
 
+    function automatic logic ccip_c0Rx_isError(
+        input t_if_ccip_c0_Rx r
+        );
+        // Speculative translation error? This field was added
+        // later, so we must test whether it is supported.
+`ifdef CCIP_RDLSPEC_AVAIL
+        return r.hdr.error;
+`else
+        return 1'b0;
+`endif
+    endfunction
+
     function automatic logic ccip_c1Rx_isWriteRsp(
         input t_if_ccip_c1_Rx r
         );

--- a/BBB_cci_mpf/hw/rtl/cci-mpf-if/cci_mpf_if_dbg.vh
+++ b/BBB_cci_mpf/hw/rtl/cci-mpf-if/cci_mpf_if_dbg.vh
@@ -157,8 +157,8 @@
                             $time, cycle,
                             print_channel(c0Rx.hdr.vc_used),
                             c0Rx.hdr.cl_num,
-                            ((c0Rx.hdr.cl_num == 0) ? "S" :
-                               cci_mpf_c0Rx_isEOP(c0Rx) ? "E" : "x"),
+                            (cci_mpf_c0Rx_isEOP(c0Rx) ? "E" :
+                               (c0Rx.hdr.cl_num == 0) ? "S" : "x"),
                             print_c0_resptype(c0Rx.hdr.resp_type),
 `ifdef CCIP_RDLSPEC_AVAIL
                             (c0Rx.hdr.error ? "ERROR " : ""),

--- a/BBB_cci_mpf/hw/rtl/cci-mpf-if/cci_mpf_if_pkg.sv
+++ b/BBB_cci_mpf/hw/rtl/cci-mpf-if/cci_mpf_if_pkg.sv
@@ -162,6 +162,12 @@ package cci_mpf_if_pkg;
         return ccip_c0Rx_isReadRsp(r);
     endfunction
 
+    function automatic logic cci_c0Rx_isError(
+        input t_if_ccip_c0_Rx r
+        );
+        return ccip_c0Rx_isError(r);
+    endfunction
+
     function automatic logic cci_c1Rx_isWriteRsp(
         input t_if_cci_c1_Rx r
         );

--- a/BBB_cci_mpf/hw/rtl/cci-mpf-shims/cci_mpf_shim_vtp/cci_mpf_shim_vtp.vh
+++ b/BBB_cci_mpf/hw/rtl/cci-mpf-shims/cci_mpf_shim_vtp/cci_mpf_shim_vtp.vh
@@ -262,6 +262,7 @@ interface cci_mpf_shim_vtp_tlb_if;
     // to compute offsets into pages.
     logic lookupEn;         // Enable the request
     t_tlb_4kb_va_page_idx lookupPageVA;
+    logic lookupIsSpeculative;
     logic lookupRdy;        // Ready to accept a request?
 
     // Did the lookup hit in the TLB cache?
@@ -269,7 +270,9 @@ interface cci_mpf_shim_vtp_tlb_if;
     // Respond with page's physical address two cycles after lookupEn
     t_tlb_4kb_pa_page_idx lookupRspPagePA;
     logic lookupRspIsBigPage;
-
+    // Is the page present in the translation table? Even failed translations
+    // are cached so that speculative loads don't keep forcing page walks.
+    logic lookupRspNotPresent;
 
     //
     // Signals for handling misses and fills.
@@ -282,29 +285,35 @@ interface cci_mpf_shim_vtp_tlb_if;
     t_tlb_4kb_pa_page_idx fillPA;
     // 2MB page? If 0 then it is a 4KB page.
     logic fillBigPage;
+    // Failed speculative translation?
+    logic fillNotPresent;
 
     modport server
        (
         input  lookupEn,
         input  lookupPageVA,
+        input  lookupIsSpeculative,
         output lookupRdy,
 
         output lookupRspHit,
         output lookupRspPagePA,
         output lookupRspIsBigPage,
+        output lookupRspNotPresent,
 
         output lookupMiss,
         output lookupMissVA,
         input  fillEn,
         input  fillVA,
         input  fillPA,
-        input  fillBigPage
+        input  fillBigPage,
+        input  fillNotPresent
         );
 
     modport client
        (
         output lookupEn,
         output lookupPageVA,
+        output lookupIsSpeculative,
         input  lookupRdy,
 
         // Responses are returned from the TLB in the order translations were
@@ -314,7 +323,8 @@ interface cci_mpf_shim_vtp_tlb_if;
         input  lookupMiss,
         input  lookupRspHit,
         input  lookupRspPagePA,
-        input  lookupRspIsBigPage
+        input  lookupRspIsBigPage,
+        input  lookupRspNotPresent
         );
 
     // Fill -- add a new translation
@@ -323,7 +333,8 @@ interface cci_mpf_shim_vtp_tlb_if;
         output fillEn,
         output fillVA,
         output fillPA,
-        output fillBigPage
+        output fillBigPage,
+        output fillNotPresent
         );
 
 endinterface

--- a/BBB_cci_mpf/hw/rtl/cci-mpf-shims/cci_mpf_shim_vtp/cci_mpf_svc_vtp_pt_walk.sv
+++ b/BBB_cci_mpf/hw/rtl/cci-mpf-shims/cci_mpf_shim_vtp/cci_mpf_svc_vtp_pt_walk.sv
@@ -507,8 +507,9 @@ module cci_mpf_svc_vtp_pt_walk
 
           STATE_PT_WALK_SPEC_ERROR:
             begin
-                rsp_en <= 1'b0;
                 state <= STATE_PT_WALK_IDLE;
+                state_is_walk_idle <= 1'b1;
+                rsp_en <= 1'b0;
             end
 
           STATE_PT_WALK_HALT:

--- a/BBB_cci_mpf/sw/src/libmpf/shim_vtp_internal.h
+++ b/BBB_cci_mpf/sw/src/libmpf/shim_vtp_internal.h
@@ -83,6 +83,7 @@ bool mpfVtpPinOnDemandMode(
  * Pin and insert a single page in the translation table.
  *
  * @param[in]  _mpf_handle Internal handle to MPF state.
+ * @param[in]  pt_locked   True if the page table manager lock is held already.
  * @param[in]  va          Virtual address of page start.
  * @param[in]  page_size   Size of the page.
  * @param[in]  flags       Flags passed to mpfVtpPtInsertPageMapping().
@@ -91,6 +92,7 @@ bool mpfVtpPinOnDemandMode(
  */
 fpga_result mpfVtpPinAndInsertPage(
     _mpf_handle_p _mpf_handle,
+    bool pt_locked,
     mpf_vtp_pt_vaddr va,
     mpf_vtp_page_size page_size,
     uint32_t flags,

--- a/BBB_cci_mpf/sw/src/libmpf/shim_vtp_srv.c
+++ b/BBB_cci_mpf/sw/src/libmpf/shim_vtp_srv.c
@@ -109,7 +109,7 @@ static fpga_result mapVA(
                      (*page_size == MPF_VTP_PAGE_2MB ? "2MB" : "4KB"));
     }
 
-    r = mpfVtpPinAndInsertPage(_mpf_handle, req_va, *page_size,
+    r = mpfVtpPinAndInsertPage(_mpf_handle, true, req_va, *page_size,
                                MPF_VTP_PT_FLAG_IN_USE, rsp_pa);
     mpfVtpPtUnlockMutex(pt);
     return r;

--- a/BBB_cci_mpf/test/test-mpf/base/hw/rtl/cci_test_afu.sv
+++ b/BBB_cci_mpf/test/test-mpf/base/hw/rtl/cci_test_afu.sv
@@ -210,6 +210,12 @@ module ccip_std_afu
         // request header.
         .ENABLE_VTP(`MPF_CONF_ENABLE_VTP),
 
+  `ifdef MPF_CONF_VTP_PT_MODE_HARDWARE_WALKER
+        .VTP_PT_MODE("HARDWARE_WALKER"),
+  `elsif MPF_CONF_VTP_PT_MODE_SOFTWARE_SERVICE
+        .VTP_PT_MODE("SOFTWARE_SERVICE"),
+  `endif
+
         // Enable mapping of eVC_VA to physical channels?  AFUs that both use
         // eVC_VA and read back memory locations written by the AFU must either
         // emit WrFence on VA or use explicit physical channels and enforce

--- a/BBB_cci_mpf/test/test-mpf/base/sw/cci_test.h
+++ b/BBB_cci_mpf/test/test-mpf/base/sw/cci_test.h
@@ -137,7 +137,7 @@ class CCI_TEST
         }
     }
 
-    uint64_t getAFUMHz()
+    uint64_t getAFUMHz(bool uclk_freq_required = true)
     {
         // What's the AFU frequency (MHz)?
         uint64_t afu_mhz = readCommonCSR(CSR_COMMON_FREQ);
@@ -155,7 +155,7 @@ class CCI_TEST
             afu_mhz = uint64_t(vm["uclk-freq"].as<int>()) >> 1;
         }
 
-        if (afu_mhz == 0)
+        if ((afu_mhz == 0) && uclk_freq_required)
         {
             cerr << "--uclk-freq must be specified when connecting to uClk_usr" << endl;
             exit(1);

--- a/BBB_cci_mpf/test/test-mpf/base/sw/cci_test_main.cpp
+++ b/BBB_cci_mpf/test/test-mpf/base/sw/cci_test_main.cpp
@@ -155,15 +155,16 @@ int main(int argc, char *argv[])
         cout << "#" << endl;
     }
 
-    uint64_t mhz = t->getAFUMHz();
-    double usec_per_cycle = 1.0 / double(mhz);
+    uint64_t mhz = t->getAFUMHz(false);
+    double usec_per_cycle = 0;
+    if (mhz) usec_per_cycle = 1.0 / double(mhz);
 
     uint64_t cycles = t->testNumCyclesExecuted();
     if (cycles != 0)
     {
         cout << "#" << endl
              << "# Test cycles executed: " << cycles
-             << " (" << mhz << " MHz)"
+             << " (" << (mhz ? std::to_string(mhz) : "unknown uClk") << " MHz)"
              << (svc.hwIsSimulated() ? " [simulated]" : "")
              << endl;
     }

--- a/BBB_cci_mpf/test/test-mpf/test_spec_load/hw/rtl/cci_mpf_test_conf.vh
+++ b/BBB_cci_mpf/test/test-mpf/test_spec_load/hw/rtl/cci_mpf_test_conf.vh
@@ -1,0 +1,42 @@
+//
+// Copyright (c) 2016, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// Neither the name of the Intel Corporation nor the names of its contributors
+// may be used to endorse or promote products derived from this software
+// without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+//
+// Test configuration.  These are in ifdefs so they can be overridden
+// by command line definitions.
+//
+
+`ifndef MPF_CONF_SORT_READ_RESPONSES
+  `define MPF_CONF_SORT_READ_RESPONSES 1
+`endif
+
+`ifndef MPF_CONF_ENABLE_VTP
+  `define MPF_CONF_ENABLE_VTP 1
+`endif

--- a/BBB_cci_mpf/test/test-mpf/test_spec_load/hw/rtl/hash32.sv
+++ b/BBB_cci_mpf/test/test-mpf/test_spec_load/hw/rtl/hash32.sv
@@ -1,0 +1,86 @@
+//
+// Copyright (c) 2017, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// Neither the name of the Intel Corporation nor the names of its contributors
+// may be used to endorse or promote products derived from this software
+// without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+module hash32
+  #(
+    parameter INITIAL_VALUE = 32'b1010011010110
+    )
+   (
+    input  logic clk,
+    input  logic reset,
+    input  logic en,
+    input  logic [31:0] new_data,
+    output logic [31:0] value
+    );
+
+    always_ff @(posedge clk)
+    begin
+        if (reset)
+        begin
+            value <= INITIAL_VALUE;
+        end
+        else if (en)
+        begin
+            value[31] <= new_data[31] ^ value[0];
+            value[30] <= new_data[30] ^ value[31];
+            value[29] <= new_data[29] ^ value[30];
+            value[28] <= new_data[28] ^ value[29];
+            value[27] <= new_data[27] ^ value[28];
+            value[26] <= new_data[26] ^ value[27];
+            value[25] <= new_data[25] ^ value[26];
+            value[24] <= new_data[24] ^ value[25];
+            value[23] <= new_data[23] ^ value[24];
+            value[22] <= new_data[22] ^ value[23];
+            value[21] <= new_data[21] ^ value[22];
+            value[20] <= new_data[20] ^ value[21];
+            value[19] <= new_data[19] ^ value[20];
+            value[18] <= new_data[18] ^ value[19];
+            value[17] <= new_data[17] ^ value[18];
+            value[16] <= new_data[16] ^ value[17];
+            value[15] <= new_data[15] ^ value[16];
+            value[14] <= new_data[14] ^ value[15];
+            value[13] <= new_data[13] ^ value[14];
+            value[12] <= new_data[12] ^ value[13];
+            value[11] <= new_data[11] ^ value[12];
+            value[10] <= new_data[10] ^ value[11];
+            value[9]  <= new_data[9] ^ value[10];
+            value[8]  <= new_data[8] ^ value[9];
+            value[7]  <= new_data[7] ^ value[8];
+            value[6]  <= new_data[6] ^ value[7] ^ value[0];
+            value[5]  <= new_data[5] ^ value[6];
+            value[4]  <= new_data[4] ^ value[5] ^ value[0];
+            value[3]  <= new_data[3] ^ value[4];
+            value[2]  <= new_data[2] ^ value[3] ^ value[0];
+            value[1]  <= new_data[1] ^ value[2] ^ value[0];
+            value[0]  <= new_data[0] ^ value[1] ^ value[0];
+        end
+    end
+
+endmodule // hash32

--- a/BBB_cci_mpf/test/test-mpf/test_spec_load/hw/rtl/sources.txt
+++ b/BBB_cci_mpf/test/test-mpf/test_spec_load/hw/rtl/sources.txt
@@ -1,0 +1,3 @@
++define+MPF_CONF_VTP_PT_MODE_HARDWARE_WALKER
+
+C:sources_common.txt

--- a/BBB_cci_mpf/test/test-mpf/test_spec_load/hw/rtl/sources_common.txt
+++ b/BBB_cci_mpf/test/test-mpf/test_spec_load/hw/rtl/sources_common.txt
@@ -1,0 +1,8 @@
+test_spec_load.json
+
+SI:../../../base/hw/sim/cci_mpf_test_base_addenda.txt
+QI:../../../base/hw/par/cci_mpf_test_base_PAR_files.qsf
+
++incdir+.
+test_spec_load.sv
+hash32.sv

--- a/BBB_cci_mpf/test/test-mpf/test_spec_load/hw/rtl/sources_pt_sw.txt
+++ b/BBB_cci_mpf/test/test-mpf/test_spec_load/hw/rtl/sources_pt_sw.txt
@@ -1,0 +1,3 @@
++define+MPF_CONF_VTP_PT_MODE_SOFTWARE_SERVICE
+
+C:sources_common.txt

--- a/BBB_cci_mpf/test/test-mpf/test_spec_load/hw/rtl/test_spec_load.json
+++ b/BBB_cci_mpf/test/test-mpf/test_spec_load/hw/rtl/test_spec_load.json
@@ -1,0 +1,30 @@
+{
+   "version": 1,
+   "afu-image": {
+      "power": 0,
+      "clock-frequency-high": "auto",
+      "clock-frequency-low": "auto",
+      "afu-top-interface":
+         {
+            "name": "ccip_std_afu",
+            "module-ports" :
+               [
+                  {
+                     "class": "cci-p",
+                     "params":
+                        {
+                           "clock": "uClk_usr"
+                        }
+                  }
+               ]
+         },
+      "accelerator-clusters":
+         [
+            {
+               "name": "test_spec_load",
+               "total-contexts": 1,
+               "accelerator-type-uuid": "9a40a882-99b7-4c90-b785-7a59ec58cc9b"
+            }
+         ]
+   }
+}

--- a/BBB_cci_mpf/test/test-mpf/test_spec_load/hw/rtl/test_spec_load.sv
+++ b/BBB_cci_mpf/test/test-mpf/test_spec_load/hw/rtl/test_spec_load.sv
@@ -1,0 +1,615 @@
+//
+// Copyright (c) 2019, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// Neither the name of the Intel Corporation nor the names of its contributors
+// may be used to endorse or promote products derived from this software
+// without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+`include "cci_mpf_if.vh"
+`include "cci_test_csrs.vh"
+
+// Generated from the AFU JSON file by afu_json_mgr
+`include "afu_json_info.vh"
+
+module test_afu
+   (
+    input  logic clk,
+
+    // Connection toward the host.  Reset comes in here.
+    cci_mpf_if.to_fiu fiu,
+
+    // CSR connections
+    test_csrs.test csrs,
+
+    // MPF tracks outstanding requests.  These will be true as long as
+    // reads or unacknowledged writes are still in flight.
+    input  logic c0NotEmpty,
+    input  logic c1NotEmpty
+    );
+
+    // Local reset to reduce fan-out
+    logic reset = 1'b1;
+    always @(posedge clk)
+    begin
+        reset <= fiu.reset;
+    end
+
+
+    localparam MAX_RD_ENGINES = 8;
+    typedef logic [$clog2(MAX_RD_ENGINES)-1 : 0] t_rd_engine_idx;
+
+    typedef logic [31:0] t_hash;
+
+
+    //
+    // Convert between byte addresses and line addresses.  The conversion
+    // is simple: adding or removing low zero bits.
+    //
+
+    localparam CL_BYTE_IDX_BITS = 6;
+    typedef logic [$bits(t_cci_clAddr) + CL_BYTE_IDX_BITS - 1 : 0] t_byteAddr;
+
+    function automatic t_cci_clAddr byteAddrToClAddr(t_byteAddr addr);
+        return addr[CL_BYTE_IDX_BITS +: $bits(t_cci_clAddr)];
+    endfunction
+
+    function automatic t_byteAddr clAddrToByteAddr(t_cci_clAddr addr);
+        return {addr, CL_BYTE_IDX_BITS'(0)};
+    endfunction
+
+
+    // ====================================================================
+    //
+    //  CSRs (simple connections to the external CSR management engine)
+    //
+    // ====================================================================
+
+    //
+    // Configuration state, set by host.
+    //
+
+    // Index of the engine to access through CSRs. This indirection reduces
+    // the number of CSR addresses required.
+    t_rd_engine_idx cur_rd_engine_csr_idx;
+
+    // Index of the last active read engine
+    t_rd_engine_idx last_rd_engine_idx;
+
+    // Read engine descriptor
+    typedef struct packed {
+        // Base address of the engine's buffer
+        t_cci_clAddr base_addr;
+
+        // Expected hash value of the buffer's data
+        t_hash expected_hash;
+    }
+    t_rd_engine_cfg;
+
+    t_rd_engine_cfg rd_engine_cfg[MAX_RD_ENGINES];
+    t_hash rd_engine_last_hash[MAX_RD_ENGINES];
+    logic [31:0] rd_engine_trips[MAX_RD_ENGINES];
+    logic [MAX_RD_ENGINES-1 : 0] rd_engine_error;
+
+    logic enabled;
+    logic [47:0] test_cycles;
+
+    always_comb
+    begin
+        // The AFU ID is a unique ID for a given program.  Here we generated
+        // one with the "uuidgen" program and stored it in the AFU's JSON file.
+        // ASE and synthesis setup scripts automatically invoke afu_json_mgr
+        // to extract the UUID into afu_json_info.vh.
+        csrs.afu_id = `AFU_ACCEL_UUID;
+
+        // Default
+        for (int i = 0; i < NUM_TEST_CSRS; i = i + 1)
+        begin
+            csrs.cpu_rd_csrs[i].data = 64'(0);
+        end
+
+        // Status
+        csrs.cpu_rd_csrs[0].data = 64'({8'(MAX_RD_ENGINES), 6'b0, c1NotEmpty, c0NotEmpty});
+        csrs.cpu_rd_csrs[1].data = 64'(test_cycles);
+        csrs.cpu_rd_csrs[2].data = 64'(rd_engine_error);
+        csrs.cpu_rd_csrs[3].data = 64'(rd_engine_trips[cur_rd_engine_csr_idx]);
+        csrs.cpu_rd_csrs[4].data = 64'(rd_engine_last_hash[cur_rd_engine_csr_idx]);
+    end
+
+
+    //
+    // Consume configuration CSR writes
+    //
+
+    // Memory address to which this AFU will write the result
+    t_ccip_clAddr result_addr;
+
+    always_ff @(posedge clk)
+    begin
+        // Enable/disable the test with bit 0 of CSR 0
+        if (csrs.cpu_wr_csrs[0].en)
+        begin
+            enabled <= csrs.cpu_wr_csrs[0].data[0];
+        end
+
+        // CSR 1: base address of the result buffer
+        if (csrs.cpu_wr_csrs[1].en)
+        begin
+            result_addr <= byteAddrToClAddr(csrs.cpu_wr_csrs[1].data);
+        end
+
+        // CSR 2: How many engines are active?
+        if (csrs.cpu_wr_csrs[2].en)
+        begin
+            last_rd_engine_idx <= t_rd_engine_idx'(csrs.cpu_wr_csrs[2].data);
+        end
+
+        // CSR 3: Set the index of the current engine to configure or read
+        if (csrs.cpu_wr_csrs[3].en)
+        begin
+            cur_rd_engine_csr_idx <= t_rd_engine_idx'(csrs.cpu_wr_csrs[3].data);
+        end
+
+        // CSR 4: Set engine base address
+        if (csrs.cpu_wr_csrs[4].en)
+        begin
+            rd_engine_cfg[cur_rd_engine_csr_idx].base_addr <=
+                byteAddrToClAddr(csrs.cpu_wr_csrs[4].data);
+        end
+
+        // CSR 5: Expected hash
+        if (csrs.cpu_wr_csrs[5].en)
+        begin
+            rd_engine_cfg[cur_rd_engine_csr_idx].expected_hash <= t_hash'(csrs.cpu_wr_csrs[5].data);
+        end
+
+        if (reset)
+        begin
+            enabled <= 1'b0;
+        end
+    end
+
+
+    // =========================================================================
+    //
+    //   State machine
+    //
+    // =========================================================================
+
+    typedef enum logic [2:0]
+    {
+        STATE_IDLE,
+        STATE_START,
+        STATE_RUN,
+        STATE_END,
+        STATE_WRITE_RESULT,
+        STATE_HALT
+    }
+    t_state;
+
+    t_state state;
+
+    always_ff @(posedge clk)
+    begin
+        if (reset)
+        begin
+            state <= STATE_IDLE;
+        end
+        else
+        begin
+            case (state)
+              STATE_IDLE:
+                begin
+                    if (enabled && ! (|(rd_engine_error)))
+                    begin
+                        state <= STATE_START;
+                        $display("AFU starting engines...");
+                    end
+                end
+
+              STATE_START:
+                begin
+                    state <= STATE_RUN;
+                end
+
+              STATE_RUN:
+                begin
+                    if (! enabled)
+                    begin
+                        state <= STATE_END;
+                        $display("AFU stopping engines...");
+                    end
+                    else if (|(rd_engine_error))
+                    begin
+                        state <= STATE_END;
+                        $display("AFU stopping engines due to error...");
+                    end
+                end
+
+              STATE_END:
+                begin
+                    if (! c0NotEmpty)
+                    begin
+                        state <= STATE_WRITE_RESULT;
+                        $display("AFU write result to 0x%x", clAddrToByteAddr(result_addr));
+                    end
+                end
+
+              STATE_WRITE_RESULT:
+                begin
+                    if (! fiu.c1TxAlmFull)
+                    begin
+                        if (|(rd_engine_error))
+                        begin
+                            state <= STATE_HALT;
+                            $display("AFU halting due to error");
+                        end
+                        else
+                        begin
+                            state <= STATE_IDLE;
+                            $display("AFU done");
+                        end
+                    end
+                end
+
+              STATE_END:
+                begin
+                end
+            endcase
+        end
+    end
+
+    always_ff @(posedge clk)
+    begin
+        if (state == STATE_RUN)
+        begin
+            test_cycles <= test_cycles + 1;
+        end
+
+        if (reset)
+        begin
+            test_cycles <= 0;
+        end
+    end
+
+
+    // ====================================================================
+    //
+    //   Random multi-line size generator
+    //
+    // ====================================================================
+
+    logic [11:0] ml_lfsr;
+    logic [$bits(t_cci_clLen) : 0] rand_rd_lines;
+    t_cci_clLen rand_rd_cl_len;
+    logic do_read;
+
+    function automatic t_cci_clLen randomMultiLineLen(logic [3:0] r);
+        t_cci_clLen cl;
+
+        case (r) inside
+            [4'd0:4'd5]:  cl = eCL_LEN_1;
+            [4'd6:4'd10]: cl = eCL_LEN_2;
+            default:      cl = eCL_LEN_4;
+        endcase
+
+        return cl;
+    endfunction
+
+    always_ff @(posedge clk)
+    begin
+        if (do_read || (state == STATE_START))
+        begin
+            rand_rd_cl_len <= randomMultiLineLen(ml_lfsr[3:0]);
+        end
+    end
+
+    cci_mpf_prim_lfsr12
+      #(
+        .INITIAL_VALUE(12'(513))
+        )
+      pwm_lfsr
+       (
+        .clk,
+        .reset,
+        .en(do_read),
+        .value(ml_lfsr)
+        );
+
+
+    // =========================================================================
+    //
+    //   Read logic.
+    //
+    // =========================================================================
+
+    //
+    // READ REQUEST
+    //
+
+    assign do_read = (state == STATE_RUN) && ! fiu.c0TxAlmFull;
+
+    // Index of the current read engine. Engines generate read requests round-robin.
+    t_rd_engine_idx cur_rd_engine_idx;
+
+    // The read epoch associates read responses with trips through the buffer. When
+    // the end of buffer tag is reached the epoch is updated. All read responses with
+    // the old epoch become unnecessary speculative reads that can be dropped.
+    logic [MAX_RD_ENGINES-1 : 0] cur_rd_epoch;
+    logic [MAX_RD_ENGINES-1 : 0] switch_rd_epoch;
+
+    t_cci_clAddr cur_rd_addr[MAX_RD_ENGINES];
+
+
+    //
+    // Emit read requests to the FIU.
+    //
+
+    // Read header defines the request to the FIU
+    t_cci_mpf_c0_ReqMemHdr rd_hdr;
+    t_cci_mpf_ReqMemHdrParams rd_hdr_params;
+
+    always_comb
+    begin
+        // Use virtual addresses
+        rd_hdr_params = cci_mpf_defaultReqHdrParams(1);
+        // Let the FIU pick the channel
+        rd_hdr_params.vc_sel = eVC_VA;
+
+        // Read a random number of lines. The random value must be legal given
+        // the current address.
+        case (cur_rd_addr[cur_rd_engine_idx][1:0])
+            2'b?1: rd_hdr_params.cl_len = eCL_LEN_1;
+            2'b00: rd_hdr_params.cl_len = rand_rd_cl_len;
+            2'b10: rd_hdr_params.cl_len = t_cci_clLen'({ 1'b0, 1'(rand_rd_cl_len[0]) });
+        endcase
+        rand_rd_lines = {1'b0, 2'(rd_hdr_params.cl_len)} + 1;
+
+        // Generate the header
+        rd_hdr = cci_mpf_c0_genReqHdr(
+                     // Alternate between the speculative read functions so both are tested
+                     (cur_rd_engine_idx[0] ? eREQ_RDLSPEC_I : eREQ_RDLSPEC_S),
+                     cur_rd_addr[cur_rd_engine_idx],
+                     // Store engine info in mdata
+                     {'0, cur_rd_engine_idx, cur_rd_epoch[cur_rd_engine_idx]},
+                     rd_hdr_params);
+    end
+
+    // Send read requests to the FIU
+    always_ff @(posedge clk)
+    begin
+        if (reset)
+        begin
+            fiu.c0Tx.valid <= 1'b0;
+        end
+        else
+        begin
+            fiu.c0Tx <= cci_mpf_genC0TxReadReq(rd_hdr, do_read);
+
+            if (do_read)
+            begin
+                $display("  Reading from VA 0x%x for engine %0d, epoch %0d",
+                         clAddrToByteAddr(cci_mpf_c0_getReqAddr(rd_hdr)),
+                         cur_rd_engine_idx, cur_rd_epoch[cur_rd_engine_idx]);
+            end
+        end
+    end
+
+    // Round-robin through engines.
+    always_ff @(posedge clk)
+    begin
+        if (reset || (state == STATE_START))
+        begin
+            cur_rd_engine_idx <= t_rd_engine_idx'(0);
+        end
+        else if (do_read)
+        begin
+            if (cur_rd_engine_idx == last_rd_engine_idx)
+            begin
+                cur_rd_engine_idx <= t_rd_engine_idx'(0);
+            end
+            else
+            begin
+                cur_rd_engine_idx <= cur_rd_engine_idx + t_rd_engine_idx'(1);
+            end
+        end
+    end
+
+
+    //
+    // Update engine next addr and epoch
+    //
+    genvar e;
+    generate
+        for (e = 0; e < MAX_RD_ENGINES; e = e + 1)
+        begin : eng_req
+            always_ff @(posedge clk)
+            begin
+                // Did this engine just read?
+                if (do_read && (cur_rd_engine_idx == t_rd_engine_idx'(e)))
+                begin
+                    // Update read address pointer
+                    cur_rd_addr[e] <= cur_rd_addr[e] + t_cci_clAddr'(rand_rd_lines);
+                end
+
+                // New epoch (happens when the read response stream finds the buffer end flag)
+                if (switch_rd_epoch[e])
+                begin
+                    // Start reading from the head of the buffer again and toggle the epoch
+                    cur_rd_addr[e] <= rd_engine_cfg[e].base_addr;
+                    cur_rd_epoch[e] <= ~cur_rd_epoch[e];
+                end
+
+                if (reset || (state == STATE_START))
+                begin
+                    cur_rd_addr[e] <= rd_engine_cfg[e].base_addr;
+                    cur_rd_epoch[e] <= 1'b0;
+                end
+            end
+        end
+    endgenerate
+
+    //
+    // READ RESPONSE HANDLING
+    //
+
+    //
+    // Extracted state from read responses
+    //
+    logic rd_rsp_valid;
+    logic rd_rsp_epoch;
+    t_rd_engine_idx rd_rsp_engine_idx;
+    logic rd_rsp_end_of_stream;
+    logic [31:0] rd_rsp_data;
+
+    always_ff @(posedge clk)
+    begin
+        rd_rsp_valid <= cci_c0Rx_isReadRsp(fiu.c0Rx) && ! cci_c0Rx_isError(fiu.c0Rx);
+        {rd_rsp_engine_idx, rd_rsp_epoch} <= fiu.c0Rx.hdr.mdata;
+
+        // Bit 0 data indicates end of stream when 1.
+        rd_rsp_end_of_stream <= fiu.c0Rx.data[0];
+
+        // Hash the low 32 bits of each line
+        rd_rsp_data <= fiu.c0Rx.data[31:0];
+
+        if (cci_c0Rx_isReadRsp(fiu.c0Rx) && cci_c0Rx_isError(fiu.c0Rx))
+        begin
+            $display("    Dropping failed speculative read, engine %0d, epoch %0d",
+                     fiu.c0Rx.hdr.mdata[1 +: $bits(t_rd_engine_idx)],
+                     fiu.c0Rx.hdr.mdata[0]);
+        end
+    end
+
+    //
+    // Consume read responses and update hashes
+    //
+    generate
+        for (e = 0; e < MAX_RD_ENGINES; e = e + 1)
+        begin : eng_rsp
+            // Hash received data for each engine.
+            logic [31:0] hash_value;
+            logic consume_rd_rsp;
+
+            hash32
+              hash
+               (
+                .clk,
+                .reset((state == STATE_IDLE) || switch_rd_epoch[e]),
+                .en(consume_rd_rsp && ! rd_rsp_end_of_stream),
+                .new_data(rd_rsp_data),
+                .value(hash_value)
+                );
+
+            // Consume a read response when it is for this engine and the
+            // response belongs to the active epoch.
+            assign consume_rd_rsp = rd_rsp_valid &&
+                                    (rd_rsp_engine_idx == t_rd_engine_idx'(e)) &&
+                                    (rd_rsp_epoch == cur_rd_epoch[e]) &&
+                                    ! switch_rd_epoch[e];
+
+            always_ff @(posedge clk)
+            begin
+                // End of stream?
+                switch_rd_epoch[e] <= consume_rd_rsp && rd_rsp_end_of_stream;
+
+                if (! reset && (consume_rd_rsp && rd_rsp_end_of_stream))
+                begin
+                    $display("    End of stream, engine %0d, epoch %0d", e, cur_rd_epoch[e]);
+                end
+            end
+
+            // Is the hash the expected value at stream end?
+            always_ff @(posedge clk)
+            begin
+                if (switch_rd_epoch[e])
+                begin
+                    rd_engine_trips[e] <= rd_engine_trips[e] + 1;
+                    rd_engine_last_hash[e] <= hash_value;
+
+                    if (hash_value != rd_engine_cfg[e].expected_hash)
+                    begin
+                        rd_engine_error[e] <= 1'b1;
+
+                        if (! reset)
+                        begin
+                            $display("    ERROR: engine %0d expected hash 0x%x, computed 0x%x", e,
+                                     rd_engine_cfg[e].expected_hash, hash_value);
+                        end
+                    end
+                end
+
+                if (reset || (state == STATE_START))
+                begin
+                    rd_engine_error[e] <= 1'b0;
+                    rd_engine_trips[e] <= 0;
+                    rd_engine_last_hash[e] <= 0;
+                end
+            end
+        end
+    endgenerate
+
+
+    // =========================================================================
+    //
+    //   Write logic.
+    //
+    // =========================================================================
+
+    // Construct a memory write request header.  For this AFU it is always
+    // the same, since we write to only one address.
+    t_cci_mpf_c1_ReqMemHdr wr_hdr;
+    assign wr_hdr = cci_mpf_c1_genReqHdr(eREQ_WRLINE_I,
+                                         result_addr,
+                                         t_cci_mdata'(0),
+                                         cci_mpf_defaultReqHdrParams(1));
+
+    // Just write a 1 to signal completion
+    assign fiu.c1Tx.data = t_ccip_clData'(1'b1);
+
+    // Control logic for memory writes
+    always_ff @(posedge clk)
+    begin
+        if (reset)
+        begin
+            fiu.c1Tx.valid <= 1'b0;
+        end
+        else
+        begin
+            // Request the write as long as the channel isn't full.
+            fiu.c1Tx.valid <= ((state == STATE_WRITE_RESULT) &&
+                               ! fiu.c1TxAlmFull);
+        end
+
+        fiu.c1Tx.hdr <= wr_hdr;
+    end
+
+
+    //
+    // This AFU never handles MMIO reads.  MMIO is managed in the CSR module.
+    //
+    assign fiu.c2Tx.mmioRdValid = 1'b0;
+
+endmodule // test_afu

--- a/BBB_cci_mpf/test/test-mpf/test_spec_load/sw/.gitignore
+++ b/BBB_cci_mpf/test/test-mpf/test_spec_load/sw/.gitignore
@@ -1,0 +1,3 @@
+test_spec_load
+test_spec_load_ase
+obj

--- a/BBB_cci_mpf/test/test-mpf/test_spec_load/sw/Makefile
+++ b/BBB_cci_mpf/test/test-mpf/test_spec_load/sw/Makefile
@@ -1,0 +1,39 @@
+include ../../base/sw/base_include.mk
+
+# Primary test name
+TEST = test_spec_load
+
+# Build directory, including generated .h files
+OBJDIR = obj
+CFLAGS += -I./$(OBJDIR)
+CPPFLAGS += -I./$(OBJDIR)
+
+# Files and folders
+SRCS = $(TEST).cpp $(BASE_FILE_SRC)
+OBJS = $(addprefix $(OBJDIR)/,$(patsubst %.cpp,%.o,$(SRCS)))
+
+# Targets
+all: $(TEST) $(TEST)_ase
+
+# AFU info from JSON file, including AFU UUID
+AFU_JSON_INFO = $(OBJDIR)/afu_json_info.h
+$(AFU_JSON_INFO): ../hw/rtl/test_spec_load.json | objdir
+	afu_json_mgr json-info --afu-json=$^ --c-hdr=$@
+$(OBJS): $(AFU_JSON_INFO)
+
+$(TEST): $(OBJS)
+	$(CXX) -o $@ $^ $(LDFLAGS) $(FPGA_LIBS)
+
+$(TEST)_ase: $(OBJS)
+	$(CXX) -o $@ $^ $(LDFLAGS) $(ASE_LIBS)
+
+$(OBJDIR)/%.o: %.cpp | objdir
+	$(CXX) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+
+clean:
+	rm -rf $(TEST) $(TEST)_ase $(OBJDIR)
+
+objdir:
+	@mkdir -p $(OBJDIR)
+
+.PHONY: all clean

--- a/BBB_cci_mpf/test/test-mpf/test_spec_load/sw/test_spec_load.cpp
+++ b/BBB_cci_mpf/test/test-mpf/test_spec_load/sw/test_spec_load.cpp
@@ -153,7 +153,12 @@ int TEST_SPEC_LOAD::test()
             // Set the engine index being probed
             writeTestCSR(3, e);
             uint64_t trips = readTestCSR(3);
-            cout << "    Engine 0 trips: " << trips << endl;
+            uint64_t dropped_reads = readTestCSR(5);
+            uint64_t spec_errors = readTestCSR(6);
+            cout << "    Engine 0 trips: " << trips
+                 << ", dropped reads: " << dropped_reads
+                 << ", spec errors: " << spec_errors
+                 << endl;
         }
 
         uint64_t error_mask = readTestCSR(2);

--- a/BBB_cci_mpf/test/test-mpf/test_spec_load/sw/test_spec_load.cpp
+++ b/BBB_cci_mpf/test/test-mpf/test_spec_load/sw/test_spec_load.cpp
@@ -1,0 +1,338 @@
+// Copyright(c) 2019, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "test_spec_load.h"
+// Generated from the AFU JSON file by afu_json_mgr
+#include "afu_json_info.h"
+
+#include <unistd.h>
+#include <time.h>
+#include <boost/format.hpp>
+#include <boost/algorithm/string.hpp>
+#include <stdlib.h>
+#include <sys/mman.h>
+
+
+// ========================================================================
+//
+// Each test must provide these functions used by main to find the
+// specific test instance.
+//
+// ========================================================================
+
+const char* testAFUID()
+{
+    return AFU_ACCEL_UUID;
+}
+
+void testConfigOptions(po::options_description &desc)
+{
+    // Add test-specific options
+    desc.add_options()
+        ("rd-engines", po::value<int>()->default_value(1), "Number of streaming read engines")
+        ("repeat", po::value<int>()->default_value(1), "Number of repetitions")
+        ("ts", po::value<int>()->default_value(1), "Test length (seconds)")
+        ;
+}
+
+CCI_TEST* allocTest(const po::variables_map& vm, SVC_WRAPPER& svc)
+{
+    return new TEST_SPEC_LOAD(vm, svc);
+}
+
+
+// ========================================================================
+//
+// Random traffic test.
+//
+// ========================================================================
+
+int TEST_SPEC_LOAD::test()
+{
+    n_rd_engines = vm["rd-engines"].as<int>();
+    uint32_t max_rd_engines = 0xff & (readTestCSR(0) >> 8);
+    if ((n_rd_engines < 1) || (n_rd_engines > max_rd_engines))
+    {
+        cerr << "Number of read engines must be between 1 and " << max_rd_engines << endl;
+        exit(1);
+    }
+
+    // Allocate memory for control
+    auto dsm_buf_handle = this->allocBuffer(getpagesize());
+    auto dsm = reinterpret_cast<volatile uint64_t*>(dsm_buf_handle->c_type());
+    assert(NULL != dsm);
+    memset((void*)dsm, 0, getpagesize());
+
+    genBuffers();
+
+    // Result buffer address
+    writeTestCSR(1, uint64_t(dsm));
+    // Last read engine index
+    writeTestCSR(2, n_rd_engines - 1);
+
+    // Configure buffers
+    for (int e = 0; e < n_rd_engines; e++)
+    {
+        // Set the engine index being configured
+        writeTestCSR(3, e);
+        // Buffer base address
+        writeTestCSR(4, (uint64_t)(mem_buf_handles[e]->c_type()));
+        // Expected hash
+        writeTestCSR(5, mem_buf_hashes[e]);
+    }
+
+    uint32_t run_sec = uint64_t(vm["ts"].as<int>());
+    uint64_t repetitions = uint64_t(vm["repeat"].as<int>());
+    uint64_t iter = 0;
+
+    while (repetitions--)
+    {
+        cout << endl << "Iteration " << iter << ":" << endl;
+
+        uint64_t vl0_lines = readCommonCSR(CCI_TEST::CSR_COMMON_VL0_RD_LINES) +
+                             readCommonCSR(CCI_TEST::CSR_COMMON_VL0_WR_LINES);
+        uint64_t vh0_lines = readCommonCSR(CCI_TEST::CSR_COMMON_VH0_LINES);
+        uint64_t vh1_lines = readCommonCSR(CCI_TEST::CSR_COMMON_VH1_LINES);
+
+        // Start the test
+        writeTestCSR(0, 1);
+
+        sleep(run_sec);
+
+        // Stop the test
+        writeTestCSR(0, 0);
+
+        // Wait for test to signal it is complete
+        while (*dsm == 0)
+        {
+        }
+
+        while (readTestCSR(0) & 3)
+        {
+            sleep(1);
+        }
+
+        uint64_t vl0_lines_n = readCommonCSR(CCI_TEST::CSR_COMMON_VL0_RD_LINES) +
+                               readCommonCSR(CCI_TEST::CSR_COMMON_VL0_WR_LINES);
+        uint64_t vh0_lines_n = readCommonCSR(CCI_TEST::CSR_COMMON_VH0_LINES);
+        uint64_t vh1_lines_n = readCommonCSR(CCI_TEST::CSR_COMMON_VH1_LINES);
+
+        cout << "    VL0 " << vl0_lines_n - vl0_lines
+             << " : VH0 " << vh0_lines_n - vh0_lines
+             << " : VH1 " << vh1_lines_n - vh1_lines
+             << endl;
+        vl0_lines = vl0_lines_n;
+        vh0_lines = vh0_lines_n;
+        vh1_lines = vh1_lines_n;
+
+        for (int e = 0; e < n_rd_engines; e++)
+        {
+            // Set the engine index being probed
+            writeTestCSR(3, e);
+            uint64_t trips = readTestCSR(3);
+            cout << "    Engine 0 trips: " << trips << endl;
+        }
+
+        uint64_t error_mask = readTestCSR(2);
+        if (0 != error_mask)
+        {
+            cout << "ERROR: engine error mask 0x" << hex << error_mask << dec << endl;
+            break;
+        }
+
+        for (int e = 0; e < n_rd_engines; e++)
+        {
+            // Set the engine index being probed
+            writeTestCSR(3, e);
+            uint64_t trips = readTestCSR(3);
+            uint64_t last_hash = readTestCSR(4);
+            assert((trips == 0) || (last_hash == mem_buf_hashes[e]));
+        }
+
+        iter += 1;
+    }
+
+    return 0;
+}
+
+
+uint64_t
+TEST_SPEC_LOAD::testNumCyclesExecuted()
+{
+    return readTestCSR(1);
+}
+
+
+int
+TEST_SPEC_LOAD::genBuffers()
+{
+    mem_buf_handles = new fpga::types::shared_buffer::ptr_t[n_rd_engines];
+    mem_buf_sizes = new size_t[n_rd_engines];
+    mem_buf_hashes = new uint32_t[n_rd_engines];
+    assert(NULL != mem_buf_handles);
+
+    // The first pass allocates the buffers
+    for (int e = 0; e < n_rd_engines; e++)
+    {
+        size_t n_bytes;
+        size_t n_alloc_bytes;
+
+        int flags = (MAP_PRIVATE | MAP_ANONYMOUS);
+
+        // Pick a size for each buffer. Usually use a few 4KB pages. Sometimes use
+        // 2MB pages.
+        //
+        // Allocate an extra page to reserve the virtual space. The extra page
+        // will be unmapped before the test begins in order to ensure there
+        // is no valid mapping.
+        if ((e & 3) == 3)
+        {
+            n_bytes = 2048 * 1024;
+            n_alloc_bytes = n_bytes + 2048 * 1024;
+            flags |= MAP_HUGETLB;
+        }
+        else
+        {
+            n_bytes = 4096 * ((e & 3) + 1);
+            n_alloc_bytes = n_bytes + 4096;
+        }
+
+        void* buf = mmap(NULL, n_alloc_bytes, (PROT_READ | PROT_WRITE), flags, -1, 0);
+        if (buf == MAP_FAILED)
+        {
+            cerr << "Failed to mmap " << n_alloc_bytes << " byte buffer" << endl;
+            exit(1);
+        }
+
+        cout << "  Allocated buffer " << e << " with mmap (" << n_bytes / 1024 << "KB) at 0x"
+             << hex << buf << dec << endl;
+
+        memset(buf, 0, n_bytes);
+        mem_buf_handles[e] = this->attachBuffer(buf, n_bytes);
+        mem_buf_sizes[e] = n_bytes;
+    }
+
+    // Now that all memory is allocated, unmap the last page of each buffer so we
+    // know that there are illegal addresses at the end of each buffer.
+    for (int e = 0; e < n_rd_engines; e++)
+    {
+        void* buf = (void*)mem_buf_handles[e]->c_type();
+        size_t n_bytes = mem_buf_sizes[e];
+
+        // Unmap the page just after the buffer
+        buf = (void*)((uint8_t*)buf + n_bytes);
+        assert(0 == munmap(buf, (n_bytes >= 2048 * 1024) ? 2048 * 1024 : 4096));
+
+        cout << "  Released guard " << e << " with munmap at 0x"
+             << hex << buf << dec << endl;
+    }
+
+    // Put random values in the low word of each line in the buffers
+    for (int e = 0; e < n_rd_engines; e++)
+    {
+        volatile uint64_t* buf = (volatile uint64_t*)mem_buf_handles[e]->c_type();
+        size_t n_bytes = mem_buf_sizes[e];
+
+        // The initial hash value must match the initial value in the hash32 RTL.
+        mem_buf_hashes[e] = 0b1010011010110;
+
+        while (n_bytes > 64)
+        {
+            // Random values, but make sure bit 0 is clear since it indicates
+            // whether the stream end is reached.
+            *buf = random() & ~uint64_t(1);
+            mem_buf_hashes[e] = hash32(mem_buf_hashes[e], *buf);
+
+            buf += 8;
+            n_bytes -= 64;
+        }
+
+        // Mark end of stream
+        *buf = 1;
+    }
+}
+
+
+uint32_t
+TEST_SPEC_LOAD::hash32(uint32_t cur_hash, uint32_t data)
+{
+    // This code matches the hash32 RTL. It isn't fast and doesn't have to be
+    // since it runs once at buffer initialization.
+
+    // Burst bits into individual buckets
+    uint8_t value[32], new_data[32], new_value[32];
+
+    for (int i = 0; i < 32; i++)
+    {
+        value[i] = cur_hash & 1;
+        cur_hash >>= 1;
+
+        new_data[i] = data & 1;
+        data >>= 1;
+    }
+
+    new_value[31] = new_data[31] ^ value[0];
+    new_value[30] = new_data[30] ^ value[31];
+    new_value[29] = new_data[29] ^ value[30];
+    new_value[28] = new_data[28] ^ value[29];
+    new_value[27] = new_data[27] ^ value[28];
+    new_value[26] = new_data[26] ^ value[27];
+    new_value[25] = new_data[25] ^ value[26];
+    new_value[24] = new_data[24] ^ value[25];
+    new_value[23] = new_data[23] ^ value[24];
+    new_value[22] = new_data[22] ^ value[23];
+    new_value[21] = new_data[21] ^ value[22];
+    new_value[20] = new_data[20] ^ value[21];
+    new_value[19] = new_data[19] ^ value[20];
+    new_value[18] = new_data[18] ^ value[19];
+    new_value[17] = new_data[17] ^ value[18];
+    new_value[16] = new_data[16] ^ value[17];
+    new_value[15] = new_data[15] ^ value[16];
+    new_value[14] = new_data[14] ^ value[15];
+    new_value[13] = new_data[13] ^ value[14];
+    new_value[12] = new_data[12] ^ value[13];
+    new_value[11] = new_data[11] ^ value[12];
+    new_value[10] = new_data[10] ^ value[11];
+    new_value[9]  = new_data[9] ^ value[10];
+    new_value[8]  = new_data[8] ^ value[9];
+    new_value[7]  = new_data[7] ^ value[8];
+    new_value[6]  = new_data[6] ^ value[7] ^ value[0];
+    new_value[5]  = new_data[5] ^ value[6];
+    new_value[4]  = new_data[4] ^ value[5] ^ value[0];
+    new_value[3]  = new_data[3] ^ value[4];
+    new_value[2]  = new_data[2] ^ value[3] ^ value[0];
+    new_value[1]  = new_data[1] ^ value[2] ^ value[0];
+    new_value[0]  = new_data[0] ^ value[1] ^ value[0];
+
+    uint32_t new_hash = 0;
+    for (int i = 0; i < 32; i++)
+    {
+        new_hash <<= 1;
+        new_hash |= new_value[31-i];
+    }
+
+    return new_hash;
+}

--- a/BBB_cci_mpf/test/test-mpf/test_spec_load/sw/test_spec_load.h
+++ b/BBB_cci_mpf/test/test-mpf/test_spec_load/sw/test_spec_load.h
@@ -1,0 +1,59 @@
+// Copyright(c) 2019, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef __TEST_SPEC_LOAD_H__
+#define __TEST_SPEC_LOAD_H__ 1
+
+#include "cci_test.h"
+
+class TEST_SPEC_LOAD : public CCI_TEST
+{
+  public:
+    TEST_SPEC_LOAD(const po::variables_map& vm, SVC_WRAPPER& svc) :
+        CCI_TEST(vm, svc),
+        n_rd_engines(0),
+        mem_buf_handles(NULL)
+    {
+    }
+
+    ~TEST_SPEC_LOAD() {};
+
+    // Returns 0 on success
+    int test();
+
+    uint64_t testNumCyclesExecuted();
+
+  private:
+    int genBuffers();
+    uint32_t hash32(uint32_t cur_hash, uint32_t data);
+
+    uint32_t n_rd_engines;
+    fpga::types::shared_buffer::ptr_t* mem_buf_handles;
+    size_t* mem_buf_sizes;
+    uint32_t* mem_buf_hashes;
+};
+
+#endif // _TEST_SPEC_LOAD_H_


### PR DESCRIPTION
- Add a test case that depends on proper handling of failed speculative translation.
- Cache failed speculation to avoid repeated page walks.
- Fix a few speculation bugs found in testing.
