### PR TITLE
Expose the VTP page table manager so it can be used by SW without VTP HW

### DIFF
--- a/BBB_cci_mpf/sw/include/opae/mpf/shim_vtp.h
+++ b/BBB_cci_mpf/sw/include/opae/mpf/shim_vtp.h
@@ -157,7 +157,7 @@ fpga_result __MPF_API__ mpfVtpBufferFree(
 /**
  * Return the IOVA associated with a virtual address.
  *
- * The function works only with addresses allocated by VTP.
+ * The function works only with addresses managed by VTP.
  *
  * @param[in]  mpf_handle  MPF handle initialized by mpfConnect().
  * @param[in]  buf_addr    Virtual base address of the allocated buffer.
@@ -167,6 +167,55 @@ fpga_result __MPF_API__ mpfVtpBufferFree(
 uint64_t __MPF_API__ mpfVtpGetIOAddress(
     mpf_handle_t mpf_handle,
     void* buf_addr
+);
+
+
+/**
+ * Mode for mpfVtpPinAndGetIOAddress.
+ */
+typedef enum
+{
+    // Lookup only: don't pin if page isn't already pinned for the FPGA.
+    MPF_VTP_PIN_MODE_LOOKUP_ONLY = 0,
+    // Standard mode: pin the page if necessary, using the flags
+    // passed in to modify fpgaPrepareBuffer().
+    MPF_VTP_PIN_MODE_STD = 1,
+    // Similar to standard mode, but try pinning the page read-only if
+    // pinning in read/write mode fails.
+    MPF_VTP_PIN_MODE_TRY_READ_ONLY = 2
+}
+mpf_vtp_pin_mode;
+
+
+/**
+ * Return the IOVA associated with a virtual address.
+ *
+ * The function works only with addresses allocated by VTP.
+ *
+ * @param[in]  mpf_handle  MPF handle initialized by mpfConnect().
+ * @param[in]  mode        Set the behavior when the page isn't already pinned.
+ * @param[in]  buf_addr    Virtual address to translate. The address does not
+ *                         have to be page aligned. Low address bits will
+ *                         be ignored.
+ * @param[out] ioaddr      The corresponding physical address (IOVA). The
+ *                         value is always the start of the page, even when
+ *                         buf_addr does not point to the page start.
+ * @param[out] page_size   Size of the pinned page. The enumeration values
+ *                         are log2(page bytes).
+ * @param[inout] flags     Flags passed to fpgaPrepareBuffer(). Assumed to be
+ *                         0 if flags is NULL. The returned value of flags
+ *                         will set FPGA_BUF_READ_ONLY when the page is pinned
+ *                         in read-only mode. Some input flags make no sense
+ *                         here and are ignored (e.g. FPGA_BUF_PREALLOCATED).
+ * @returns                FPGA_OK on success.
+ */
+fpga_result __MPF_API__ mpfVtpPinAndGetIOAddress(
+    mpf_handle_t mpf_handle,
+    mpf_vtp_pin_mode mode,
+    void* buf_addr,
+    uint64_t* ioaddr,
+    mpf_vtp_page_size* page_size,
+    int* flags
 );
 
 

--- a/BBB_cci_mpf/sw/src/libmpf/connect.c
+++ b/BBB_cci_mpf/sw/src/libmpf/connect.c
@@ -91,14 +91,10 @@ fpga_result __MPF_API__ mpfConnect(
 
     _mpf_find_features(_mpf_handle);
 
-    //
-    // Initialize features that require it.
-    //
-    if (mpfShimPresent(_mpf_handle, CCI_MPF_SHIM_VTP))
-    {
-        r = mpfVtpInit(_mpf_handle);
-        if (FPGA_OK != r) return r;
-    }
+    // Initialize VTP, even if no VTP hardware is present. Software may still
+    // use VTP to manage a collection of virtual to physical page translations.
+    r = mpfVtpInit(_mpf_handle);
+    if (FPGA_OK != r) return r;
 
     return FPGA_OK;
 }
@@ -111,14 +107,9 @@ fpga_result __MPF_API__ mpfDisconnect(
     fpga_result r;
     _mpf_handle_p _mpf_handle = (_mpf_handle_p)mpf_handle;
 
-    //
-    // Terminate features that require it.
-    //
-    if (mpfShimPresent(_mpf_handle, CCI_MPF_SHIM_VTP))
-    {
-        r = mpfVtpTerm(_mpf_handle);
-        if (FPGA_OK != r) return r;
-    }
+    // Terminate VTP.
+    r = mpfVtpTerm(_mpf_handle);
+    if (FPGA_OK != r) return r;
 
     free(_mpf_handle);
 

--- a/BBB_cci_mpf/sw/src/libmpf/shim_vtp_internal.h
+++ b/BBB_cci_mpf/sw/src/libmpf/shim_vtp_internal.h
@@ -125,7 +125,7 @@ typedef struct
     bool use_fpga_buf_preallocated;
 
     // Is VTP available in the FPGA?
-    bool is_available;
+    bool is_hw_vtp_available;
 
     // State of the invalidation register toggle. This value is coordinated
     // with CCI_MPF_VTP_CSR_INVAL_PAGE_VADDR in order to detect completion

--- a/BBB_cci_mpf/sw/src/libmpf/shim_vtp_pt.h
+++ b/BBB_cci_mpf/sw/src/libmpf/shim_vtp_pt.h
@@ -137,6 +137,11 @@ typedef struct
     // PT mutex (one update at a time)
     mpf_os_mutex_handle mutex;
 
+    // Cache of most recent node in findTerminalNodeAndIndex().
+    mpf_vtp_pt_node* prev_find_term_node;
+    mpf_vtp_pt_vaddr prev_va;
+    uint32_t prev_depth;
+
     // Is there a harware page table walker? If yes, the page table must be
     // pinned.
     bool hw_pt_walker_present;

--- a/BBB_cci_mpf/sw/src/libmpf/shim_vtp_pt.h
+++ b/BBB_cci_mpf/sw/src/libmpf/shim_vtp_pt.h
@@ -136,6 +136,10 @@ typedef struct
 
     // PT mutex (one update at a time)
     mpf_os_mutex_handle mutex;
+
+    // Is there a harware page table walker? If yes, the page table must be
+    // pinned.
+    bool hw_pt_walker_present;
 }
 mpf_vtp_pt;
 
@@ -305,7 +309,9 @@ fpga_result mpfVtpPtRemovePageMapping(
  * Translate an address from virtual to physical.
  *
  * @param[in]  pt          Page table.
- * @param[in]  va          Virtual address to remove.
+ * @param[in]  va          Virtual address to translate. The address does not
+ *                         have to be page aligned. Low address bits will
+ *                         be ignored.
  * @param[in]  set_in_use  Set the MPF_VTP_PT_FLAG_IN_USE in the page table
  *                         indicating that the translation has been sent
  *                         to the FPGA.

--- a/BBB_cci_mpf/sw/src/libmpf/shim_vtp_pt.h
+++ b/BBB_cci_mpf/sw/src/libmpf/shim_vtp_pt.h
@@ -306,6 +306,21 @@ fpga_result mpfVtpPtRemovePageMapping(
 
 
 /**
+ * Release a virtual range of pinned pages.
+ *
+ * @param[in]  pt          Page table.
+ * @param[in]  min_va      Start address to release.
+ * @param[in]  max_va      End address to release (exclusive).
+ * @returns                FPGA_OK on success.
+ */
+fpga_result mpfVtpPtReleaseRange(
+    mpf_vtp_pt* pt,
+    void* min_va,
+    void* max_va
+);
+
+
+/**
  * Translate an address from virtual to physical.
  *
  * @param[in]  pt          Page table.

--- a/BBB_cci_mpf/test/test-mpf/test_mem_perf/hw/rtl/cci_mpf_test_conf.vh
+++ b/BBB_cci_mpf/test/test-mpf/test_mem_perf/hw/rtl/cci_mpf_test_conf.vh
@@ -41,5 +41,8 @@
   `define MPF_CONF_ENABLE_VC_MAP 1
 `endif
 
+// Software translation service
+//`define MPF_CONF_VTP_PT_MODE_SOFTWARE_SERVICE
+
 // Enable flow control management in cci_test_afu
 `define CCI_TEST_FLOW_CONTROL

--- a/BBB_cci_mpf/test/test-mpf/test_random/hw/rtl/cci_mpf_test_conf.vh
+++ b/BBB_cci_mpf/test/test-mpf/test_random/hw/rtl/cci_mpf_test_conf.vh
@@ -45,6 +45,9 @@
   `define MPF_CONF_ENABLE_VTP 1
 `endif
 
+// Software translation service
+//`define MPF_CONF_VTP_PT_MODE_SOFTWARE_SERVICE
+
 `ifndef MPF_CONF_ENABLE_VC_MAP
   `define MPF_CONF_ENABLE_VC_MAP 1
 `endif


### PR DESCRIPTION
Software may wish to maintain a large pool of pinned pages. VTP already had methods to manage
such a pool, so we may as well expose them for SW-only use.

- Initialize VTP even when no HW is present.
- Moved the method that pins a page if needed and returns its IOVA to the primary VTP module.
- Add a simple one entry cache to the SW page table walker, since VA->PA may be a critical path.
