### PR TITLE
ci: add github-based python static analysis

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 88

--- a/.github/workflows/python-static-analysis.yml
+++ b/.github/workflows/python-static-analysis.yml
@@ -1,0 +1,56 @@
+name: python static analysis
+
+on:
+  push:
+    paths:
+      - '**.py'
+      - '.github/workflows/python-static-analysis.yml'
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Update
+      run: sudo apt-get update -y
+    - name: Setup python${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install pylint flake8 bandit
+    - name: Pylint lint
+      run: |
+        pylint $(find ${{ github.workspace }} -name "*.py") \
+          -E -f parseable --disable=E0401 --ignore=__init__.py \
+          --ignore-patterns="test_.*.py" \
+          | tee ${{ github.workspace }}/pylint.log
+    - name: Flake8 lint
+      run: |
+        flake8 $(find ${{ github.workspace }} -name "*.py") \
+          --count --show-source --statistics \
+          | tee ${{ github.workspace }}/flake8.log
+      continue-on-error: true
+    - name: Bandit scan
+      run: |
+        bandit -r $(find ${{ github.workspace }} -name "*.py") \
+          --format txt \
+          | tee ${{ github.workspace }}/bandit.log
+        bandit -r $(find ${{ github.workspace }} -name "*.py") \
+          --format csv \
+          | tee ${{ github.workspace }}/bandit.log.csv
+    - name: Archive results
+      uses: actions/upload-artifact@v2
+      with:
+        name: static-analysis
+        path: |
+          ${{ github.workspace }}/pylint.log
+          ${{ github.workspace }}/flake8.log
+          ${{ github.workspace }}/bandit.log
+          ${{ github.workspace }}/bandit.log.csv

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[format]
+max-line-length = 88         # Compatibility with 'black'


### PR DESCRIPTION
Add the following GitHub CI actions for the repository's python files:
 - python lint (`pylint`)
 - python code style check (`flake8`)
 - python security scan (`bandit`)

Signed-off-by: Marroquin, Asgard <asgard.marroquin@intel.com>