### PR TITLE
Fix underflow in vtpPinRegion

### DIFF
--- a/BBB_cci_mpf/sw/src/libmpf/shim_vtp.c
+++ b/BBB_cci_mpf/sw/src/libmpf/shim_vtp.c
@@ -171,7 +171,14 @@ static fpga_result vtpPinRegion(
         // The alloc flags are set only on the first page
         pt_flags &= ~(MPF_VTP_PT_FLAG_ALLOC | MPF_VTP_PT_FLAG_PREALLOC);
         page += this_page_bytes;
-        len -= this_page_bytes;
+        if (this_page_bytes < len)
+        {
+            len -= this_page_bytes;
+        }
+        else
+        {
+            len = 0;
+        }
 
         mpfVtpPtUnlockMutex(_mpf_handle->vtp.pt);
     }


### PR DESCRIPTION
When pinning pre-allocated memory it is possible to underflow the
len counter that tracks remaining bytes to pin.

Example of when this can happen is calling mpfVtpPrepareBuffer
with an addresses aligned to 2MB boundary and asking for buffer
length of 2MB + 64 bytes.  The first time through the loop in
vtpPinRegion will decrement len by 2MB leaving 64 bytes. The second
time through the loop will decrement 64 bytes by 2MB (assuming
the address is allocated in 2M hugepage). Now the unsigned len
value underflows to a large value.  And the vtpPinRegion continues
attempting to pin pages in the region until it fails and returns
with error.

Solution is to set len to 0 instead of underflowing when the size
of pages that was just pinned is larger than the remaining
number of bytes that need to be pinned.