### PR TITLE
mpfVtpPinAndGetIOAddressVec_hang_fix

### DIFF
--- a/BBB_cci_mpf/sw/src/libmpf/shim_vtp.c
+++ b/BBB_cci_mpf/sw/src/libmpf/shim_vtp.c
@@ -1012,7 +1012,11 @@ fpga_result __MPF_API__ mpfVtpPinAndGetIOAddressVec(
     // Need to pin the memory. At most one translation will be returned.
     if (num_pages) *num_pages = 1;
 
-    if (MPF_VTP_PIN_MODE_LOOKUP_ONLY == mode) return r;
+    if (MPF_VTP_PIN_MODE_LOOKUP_ONLY == mode)
+    {
+        mpfVtpPtUnlockMutex(pt);
+        return r;
+    }
 
     // What size is the underlying physical page? As an optimization, if
     // mpfVtpPtTranslateVAtoPA indicates failure at the 4KB level then we


### PR DESCRIPTION
1) When we use USM , we use shared_alloc, host_alloc to allocate Unified Shared Memory. mpfvtp is used to prepare buffer (map, pin) under the hood. So we don't need to prepare buffer again during DMA and expecially should not release buffer (that's a wrong implementation). So updated mmd_dma.ccp code to use mpfVtpPinAndGetIOAddressVec() function with mode - MPF_VTP_PIN_MODE_LOOKUP_ONLY , which returns FPGA_OK if pages we are trying to pin are already pinned, in that case take it as hint that USM allocation was done and don't pin or unpin during DMA operation. 2) Bug in MPF mpfVtpPinAndGetIOAddressVec() code. I was trying out the update I mentioned and I observed fpga_result __MPF_API__ mpfVtpPinAndGetIOAddressVec() hangs. It hangs when r = mpfVtpPtTranslateVAtoPA(pt, buf_addr, true, ioaddr, page_size, &pt_flags); doesn’t return FPGA_OK. In that case it will execute - if (MPF_VTP_PIN_MODE_LOOKUP_ONLY == mode) return r. So it doesn’t mpfVtpPtUnlockMutex(Pt). I changed it to if (MPF_VTP_PIN_MODE_LOOKUP_ONLY == mode) { mpfVtpPtUnlockMutex(pt); return r;}   , it worked fine.