### PR TITLE
Add reference counts to pages managed by VTP

### DIFF
--- a/BBB_cci_mpf/sw/include/opae/mpf/shim_vtp.h
+++ b/BBB_cci_mpf/sw/include/opae/mpf/shim_vtp.h
@@ -94,8 +94,9 @@ bool __MPF_API__ mpfVtpIsAvailable(
  * addresses.
  *
  * The FPGA_BUF_PREALLOCATED flag has requirements and semantics that
- * match fpgaPrepareBuffer. When set, buf_addr must point to the
- * page-aligned start of an existing virtual buffer. VTP will call
+ * match fpgaPrepareBuffer. When set, buf_addr must point to an
+ * existing virtual buffer. There are NO ALIGNMENT REQUIREMENTS for
+ * buf_addr. VTP will determine the underlying page alignment and call
  * OPAE to share the buffer with the FPGA and will also add the
  * buffer to VTP's address translation table.
  *
@@ -141,6 +142,9 @@ fpga_result __MPF_API__ mpfVtpBufferAllocate(
  * If the buffer was allocated without setting FPGA_BUF_PREALLOCATED
  * this call will deallocate/free the memory. Otherwise, the memory
  * will only be returned to it's previous state (unpinned).
+ *
+ * buf_addr must exactly match an address that is managed by
+ * mpfVtpPrepareBuffer().
  *
  * @param[in]  mpf_handle  MPF handle initialized by mpfConnect().
  * @param[in]  buf_addr    Virtual base address of the allocated buffer.

--- a/BBB_cci_mpf/sw/src/libmpf/shim_vtp.c
+++ b/BBB_cci_mpf/sw/src/libmpf/shim_vtp.c
@@ -118,7 +118,7 @@ static fpga_result vtpPinRegion(
         {
             mpf_vtp_pt_paddr existing_pa;
             uint32_t existing_flags;
-            r = mpfVtpPtTranslateVAtoPA(_mpf_handle->vtp.pt, page, false,
+            r = mpfVtpPtTranslateVAtoPA(_mpf_handle->vtp.pt, page, false, NULL,
                                         &existing_pa, &this_page_size, &existing_flags);
             if (FPGA_OK == r)
             {
@@ -130,7 +130,13 @@ static fpga_result vtpPinRegion(
                 len += (page - page_start);
                 page = page_start;
 
-                goto already_pinned;
+                // The page is already present in the table. Just increment
+                // the reference count -- a side effect of inserting the mapping.
+                // wsid is ignored.
+                r = mpfVtpPtInsertPageMapping(_mpf_handle->vtp.pt, page, existing_pa, -1,
+                                              this_page_size, pt_flags);
+                if (FPGA_OK != r) return r;
+                goto huge_success;
             }
         }
 
@@ -169,14 +175,6 @@ static fpga_result vtpPinRegion(
         if (FPGA_OK != r) goto fail;
 
       huge_success:
-        if (pt_flags)
-        {
-            mpfVtpPtSetAllocBufSize(_mpf_handle->vtp.pt, page, len);
-        }
-
-      already_pinned:
-        // The alloc flags are set only on the first page
-        pt_flags &= ~(MPF_VTP_PT_FLAG_ALLOC | MPF_VTP_PT_FLAG_PREALLOC);
         page += this_page_bytes;
         if (this_page_bytes < len)
         {
@@ -204,8 +202,9 @@ static fpga_result vtpPinRegion(
 static fpga_result vtpPreallocBuffer(
     _mpf_handle_p _mpf_handle,
     uint64_t len,
-    void** buf_addr,
-    int fpga_flags      // enum fpga_buffer_flags
+    void* buf_addr,
+    void** buf_page_addr, // address of the start of the page holding buf_addr
+    int fpga_flags        // enum fpga_buffer_flags
 )
 {
     fpga_result r;
@@ -224,7 +223,7 @@ static fpga_result vtpPreallocBuffer(
     }
 
     // Buffer is already allocated, check addresses.
-    if ((NULL == *buf_addr) || ((size_t)*buf_addr & p_mask))
+    if ((NULL == buf_addr) || ((size_t)buf_addr & p_mask))
     {
         if (_mpf_handle->dbg_mode)
         {
@@ -242,18 +241,19 @@ static fpga_result vtpPreallocBuffer(
         return FPGA_INVALID_PARAM;
     }
 
-    uint8_t* page = *buf_addr;
+    uint8_t* page = buf_addr;
 
     // Align buffer start to the page size
     mpf_vtp_page_size this_page_size;
-    r = mpfOsGetPageSize(*buf_addr, &this_page_size);
+    r = mpfOsGetPageSize(buf_addr, &this_page_size);
     size_t this_page_bytes = mpfPageSizeEnumToBytes(this_page_size);
     if (FPGA_OK != r) return FPGA_NO_MEMORY;
 
     // Mask out page offset bits
     page = (uint8_t*)((uint64_t)page & ~(this_page_bytes - 1));
+    *buf_page_addr = page;
     // Adjust the buffer length so it ends where it used to
-    len += (uint64_t)*buf_addr - (uint64_t)page;
+    len += (uint64_t)buf_addr - (uint64_t)page;
 
     // Share each page with the FPGA and insert them into the VTP page table.
     uint32_t pt_flags = MPF_VTP_PT_FLAG_PREALLOC;
@@ -300,7 +300,7 @@ static fpga_result vtpAllocBuffer(
     // Round len up to the page size
     len = (len + page_bytes - 1) & ~(page_bytes - 1);
 
-    if (_mpf_handle->dbg_mode) MPF_FPGA_MSG("requested 0x%" PRIx64 " byte buffer", len);
+     if (_mpf_handle->dbg_mode) MPF_FPGA_MSG("requested 0x%" PRIx64 " byte buffer", len);
 
 #ifdef FPGA_NEAR_MEM_MAP
     struct bitmask *numa_mems_preserve = NULL;
@@ -607,6 +607,10 @@ fpga_result mpfVtpInit(
     r = mpfVtpPtInit(_mpf_handle, &(_mpf_handle->vtp.pt));
     if (FPGA_OK != r) return r;
 
+    // Initialize the buffer tracking table
+    r = mpfVtpBuffersInit(_mpf_handle);
+    if (FPGA_OK != r) return r;
+
     if (mpfShimPresent(_mpf_handle, CCI_MPF_SHIM_VTP))
     {
         uint64_t vtp_mode;
@@ -639,6 +643,7 @@ fpga_result mpfVtpInit(
 
   fail:
     mpfVtpPtTerm(_mpf_handle->vtp.pt);
+    mpfVtpBuffersTerm(_mpf_handle);
     return r;
 }
 
@@ -672,6 +677,10 @@ fpga_result mpfVtpTerm(
 
     r = mpfVtpPtTerm(_mpf_handle->vtp.pt);
     _mpf_handle->vtp.pt = NULL;
+    if (FPGA_OK == r_ret) r_ret = r;
+
+    r = mpfVtpBuffersTerm(_mpf_handle);
+    _mpf_handle->vtp.user_buffers = NULL;
     if (FPGA_OK == r_ret) r_ret = r;
 
 #ifdef FPGA_NEAR_MEM_MAP
@@ -771,20 +780,29 @@ fpga_result __MPF_API__ mpfVtpPrepareBuffer(
     fpga_result r;
     _mpf_handle_p _mpf_handle = (_mpf_handle_p)mpf_handle;
     bool preallocated = (flags & FPGA_BUF_PREALLOCATED);
+    void* buf_page_addr;
 
     if ((NULL == buf_addr) || (0 == len)) return FPGA_INVALID_PARAM;
 
     if (preallocated)
     {
-        r = vtpPreallocBuffer(_mpf_handle, len, buf_addr, flags);
+        r = vtpPreallocBuffer(_mpf_handle, len, *buf_addr, &buf_page_addr, flags);
     }
     else
     {
         r = vtpAllocBuffer(_mpf_handle, len, buf_addr, flags);
+        buf_page_addr = *buf_addr;
+    }
+
+    if (FPGA_OK == r)
+    {
+        r = mpfVtpBuffersInsert(_mpf_handle, *buf_addr, len, buf_page_addr);
     }
 
     if (_mpf_handle->dbg_mode)
     {
+        mpfVtpDumpBuffers(_mpf_handle);
+
         mpfVtpPtLockMutex(_mpf_handle->vtp.pt);
         mpfVtpPtDumpPageTable(_mpf_handle->vtp.pt);
         mpfVtpPtUnlockMutex(_mpf_handle->vtp.pt);
@@ -817,6 +835,8 @@ fpga_result __MPF_API__ mpfVtpReleaseBuffer(
     uint32_t flags;
     uint64_t wsid;
     fpga_result r;
+    size_t page_bytes;
+    mpf_vtp_pt_vaddr buf_va_start, buf_va_end;
 
     if (_mpf_handle->dbg_mode)
     {
@@ -826,7 +846,8 @@ fpga_result __MPF_API__ mpfVtpReleaseBuffer(
     mpfVtpPtLockMutex(_mpf_handle->vtp.pt);
 
     // Is the address the beginning of an allocation region?
-    r = mpfVtpPtTranslateVAtoPA(_mpf_handle->vtp.pt, va, false, &pa, NULL, &flags);
+    r = mpfVtpPtTranslateVAtoPA(_mpf_handle->vtp.pt, va, false, &buf_va_start,
+                                &pa, NULL, &flags);
     if ((FPGA_OK != r) ||
         (0 == (flags & (MPF_VTP_PT_FLAG_ALLOC | MPF_VTP_PT_FLAG_PREALLOC))))
     {
@@ -839,13 +860,21 @@ fpga_result __MPF_API__ mpfVtpReleaseBuffer(
         return FPGA_NO_MEMORY;
     }
 
-    // Get buffer range, stored in the page table.
-    mpf_vtp_pt_vaddr buf_va_start, buf_va_end;
-    size_t buf_size;
-    r = mpfVtpPtGetAllocBufSize(_mpf_handle->vtp.pt, va, &buf_va_start, &buf_size);
     mpfVtpPtUnlockMutex(_mpf_handle->vtp.pt);
-    buf_va_end = (char *)buf_va_start + buf_size;
-    if (FPGA_OK != r) return r;
+
+    // Get buffer size and remove it from the tracking table.
+    size_t buf_size = mpfVtpBuffersRemove(_mpf_handle, va, &buf_va_start);
+    if (0 == buf_size)
+    {
+        // Pin on demand mode doesn't store preallocated regions. Just ignore
+        // errors when there is no record of the underlying buffer.
+        if (mpfVtpPinOnDemandMode(_mpf_handle)) return FPGA_OK;
+
+        return FPGA_NO_MEMORY;
+    }
+
+    buf_va_end = (char *)va + buf_size;
+    va = buf_va_start;
 
     // Loop through the mapped virtual pages until the end of the region
     // is reached or there is an error.
@@ -860,6 +889,18 @@ fpga_result __MPF_API__ mpfVtpReleaseBuffer(
         r = mpfVtpPtRemovePageMapping(_mpf_handle->vtp.pt, va,
                                       &pa, &wsid, &size, NULL);
         mpfVtpPtUnlockMutex(_mpf_handle->vtp.pt);
+        if (FPGA_BUSY == r)
+        {
+            // FPGA_BUSY is returned if the reference count of the page
+            // is greater than one. Keep the page mapped.
+            if (_mpf_handle->dbg_mode)
+            {
+                MPF_FPGA_MSG("keeping VA %p -- multiple references", va);
+            }
+
+            goto keep_page;
+        }
+
         if (FPGA_OK != r)
         {
             if (_mpf_handle->dbg_mode)
@@ -878,8 +919,6 @@ fpga_result __MPF_API__ mpfVtpReleaseBuffer(
                          va, pa, wsid);
         }
 
-        size_t page_bytes = mpfPageSizeEnumToBytes(size);
-
         r = mpfVtpInvalHWVAMapping(_mpf_handle, va);
         if (FPGA_OK != r) break;
 
@@ -887,12 +926,16 @@ fpga_result __MPF_API__ mpfVtpReleaseBuffer(
         // is bound to happen.
         assert(FPGA_OK == fpgaReleaseBuffer(_mpf_handle->handle, wsid));
 
+      keep_page:
         // Next page address
+        page_bytes = mpfPageSizeEnumToBytes(size);
         va = (char *) va + page_bytes;
 
         // Done?
         if (va >= buf_va_end)
         {
+            if (_mpf_handle->dbg_mode) mpfVtpDumpBuffers(_mpf_handle);
+
             mpfVtpPtLockMutex(_mpf_handle->vtp.pt);
             if (_mpf_handle->dbg_mode) mpfVtpPtDumpPageTable(_mpf_handle->vtp.pt);
             mpfVtpPtUnlockMutex(_mpf_handle->vtp.pt);
@@ -940,7 +983,7 @@ uint64_t __MPF_API__ mpfVtpGetIOAddress(
 
     uint64_t pa;
     mpfVtpPtLockMutex(_mpf_handle->vtp.pt);
-    r = mpfVtpPtTranslateVAtoPA(_mpf_handle->vtp.pt, buf_addr, false, &pa, NULL, NULL);
+    r = mpfVtpPtTranslateVAtoPA(_mpf_handle->vtp.pt, buf_addr, false, NULL, &pa, NULL, NULL);
     mpfVtpPtUnlockMutex(_mpf_handle->vtp.pt);
     if (FPGA_OK != r) return 0;
 
@@ -973,7 +1016,7 @@ fpga_result __MPF_API__ mpfVtpPinAndGetIOAddressVec(
     }
     mpfVtpPtLockMutex(pt);
 
-    r = mpfVtpPtTranslateVAtoPA(pt, buf_addr, true, ioaddr, page_size, &pt_flags);
+    r = mpfVtpPtTranslateVAtoPA(pt, buf_addr, true, NULL, ioaddr, page_size, &pt_flags);
     if (FPGA_OK == r)
     {
         // Already mapped. Should more virtually contiguous translations

--- a/BBB_cci_mpf/sw/src/libmpf/shim_vtp_buffers.c
+++ b/BBB_cci_mpf/sw/src/libmpf/shim_vtp_buffers.c
@@ -1,0 +1,266 @@
+//
+// Copyright (c) 2023, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// Neither the name of the Intel Corporation nor the names of its contributors
+// may be used to endorse or promote products derived from this software
+// without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <inttypes.h>
+#include <sys/mman.h>
+
+#include <opae/mpf/mpf.h>
+#include "mpf_internal.h"
+
+
+//
+// Hash buffer address to a bucket in the table.
+//
+static inline uint32_t table_hash(void *vaddr)
+{
+    uint64_t h = (uint64_t)vaddr % 17659;
+    return h % MPF_VTP_BUFFERS_TABLE_SIZE;
+}
+
+
+//
+// Size of the user_buffers table struct, rounded up to a multiple of pages.
+//
+static inline size_t table_size_bytes(void)
+{
+    size_t s = sizeof(mpf_vtp_buffer_hash_table);
+    size_t pg_size = getpagesize();
+
+    return (s + pg_size - 1) & ~(pg_size - 1);
+}
+
+
+fpga_result mpfVtpBuffersInit(
+    _mpf_handle_p _mpf_handle
+)
+{
+    fpga_result r;
+
+    // Internal double initialization -- fatal
+    assert(NULL == _mpf_handle->vtp.user_buffers);
+
+    mpf_vtp_buffer_hash_table* t;
+    t = mmap(NULL, table_size_bytes(), (PROT_READ | PROT_WRITE),
+             MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+
+    if (MAP_FAILED == t)
+    {
+        return FPGA_NO_MEMORY;
+    }
+
+    memset(t, 0, sizeof(mpf_vtp_buffer_hash_table));
+
+    // Allocate a mutex that protects the buffer table manager
+    r = mpfOsPrepareMutex(&t->mutex);
+    if (FPGA_OK != r)
+    {
+        munmap(t, table_size_bytes());
+        return r;
+    }
+
+    _mpf_handle->vtp.user_buffers = t;
+    return FPGA_OK;
+}
+
+
+fpga_result mpfVtpBuffersTerm(
+    _mpf_handle_p _mpf_handle
+)
+{
+    mpf_vtp_buffer_hash_table* table = _mpf_handle->vtp.user_buffers;
+
+    if (table)
+    {
+        // Release all the tracked buffers in the hash table.
+        for (uint32_t i = 0; i < MPF_VTP_BUFFERS_TABLE_SIZE; i += 1)
+        {
+            mpf_vtp_buffer_desc_p d = table->buckets[i];
+            while (d)
+            {
+                mpf_vtp_buffer_desc_p next = d->next;
+                free(d);
+                d = next;
+            }
+        }
+
+        mpfOsDestroyMutex(table->mutex);
+        munmap(table, table_size_bytes());
+    }
+
+    _mpf_handle->vtp.user_buffers = NULL;
+    return FPGA_OK;
+}
+
+
+fpga_result mpfVtpBuffersInsert(
+    _mpf_handle_p _mpf_handle,
+    void* vaddr,
+    size_t size,
+    void* page_vaddr
+)
+{
+    mpf_vtp_buffer_hash_table* table = _mpf_handle->vtp.user_buffers;
+
+    if (NULL == table || NULL == vaddr || 0 == size)
+    {
+        return FPGA_EXCEPTION;
+    }
+
+    uint32_t idx = table_hash(vaddr);
+    mpf_vtp_buffer_desc_p desc = malloc(sizeof(struct mpf_vtp_buffer_desc));
+    if (NULL == desc)
+    {
+        return FPGA_NO_MEMORY;
+    }
+
+    mpfOsLockMutex(table->mutex);
+    desc->vaddr = vaddr;
+    desc->size = size;
+    desc->page_vaddr = page_vaddr;
+    desc->next = table->buckets[idx];
+    table->buckets[idx] = desc;
+
+    if (_mpf_handle->dbg_mode)
+    {
+        printf(" VTP buffer insert: VA %p - %p (0x%" PRIx64 " bytes) - page %p\n",
+               vaddr, vaddr + size, size, page_vaddr);
+    }
+    mpfOsUnlockMutex(table->mutex);
+
+    return FPGA_OK;
+}
+
+
+size_t mpfVtpBuffersRemove(
+    _mpf_handle_p _mpf_handle,
+    void* vaddr,
+    void** page_vaddr
+)
+{
+    mpf_vtp_buffer_hash_table* table = _mpf_handle->vtp.user_buffers;
+    if (NULL == table)
+    {
+        return 0;
+    }
+
+    //
+    // Find the smallest buffer at address. Unfortunately, this means searching
+    // the entire list. We assume that the number of buffers being managed is
+    // relatively small. The number of pages may be high, but buffers can span
+    // lots of pages.
+    //
+    // It is possible that multiple buffers will have the same start address
+    // since small regions may share the same page and callers may pass in
+    // page-aligned addresses. The smallest buffer is returned first since
+    // there is no way to know which buffer is actually being released.
+    // When multiple buffers map to the same location, reference counts
+    // in the VTP page table keep pages allocated until the count reaches 0.
+    //
+
+    uint32_t idx = table_hash(vaddr);
+    mpf_vtp_buffer_desc_p match_prev = NULL;
+    mpf_vtp_buffer_desc_p match = NULL;
+    size_t size = 0;
+
+    mpfOsLockMutex(table->mutex);
+    mpf_vtp_buffer_desc_p cur = NULL;
+    mpf_vtp_buffer_desc_p next = table->buckets[idx];
+    while (next)
+    {
+        // A new smallest match?
+        if ((next->vaddr == vaddr) && ((size == 0) || (next->size < size)))
+        {
+            size = next->size;
+            match = next;
+            match_prev = cur;
+        }
+
+        cur = next;
+        next = cur->next;
+    }
+
+    if (match)
+    {
+        // Found a match. Remove it from the table.
+        if (match_prev)
+            match_prev->next = match->next;
+        else
+            table->buckets[idx] = match->next;
+
+        if (NULL != page_vaddr)
+        {
+            *page_vaddr = match->page_vaddr;
+        }
+
+        if (_mpf_handle->dbg_mode)
+        {
+            printf(" VTP buffer remove: VA %p - %p (0x%" PRIx64 " bytes)\n", vaddr, vaddr + size, size);
+        }
+        free(match);
+    }
+    else if (_mpf_handle->dbg_mode)
+    {
+        printf(" VTP buffer no match for VA %p\n", vaddr);
+    }
+
+    mpfOsUnlockMutex(table->mutex);
+
+    return size;
+}
+
+
+void mpfVtpDumpBuffers(
+    _mpf_handle_p _mpf_handle
+)
+{
+    mpf_vtp_buffer_hash_table* table = _mpf_handle->vtp.user_buffers;
+    if (NULL == table)
+    {
+        return;
+    }
+
+    mpfOsLockMutex(table->mutex);
+    printf("VTP Buffer Table:\n");
+    for (uint32_t i = 0; i < MPF_VTP_BUFFERS_TABLE_SIZE; i += 1)
+    {
+        mpf_vtp_buffer_desc_p d = table->buckets[i];
+        while (d)
+        {
+            printf("  VA %p - %p (0x%" PRIx64 " bytes) - page %p\n",
+                   d->vaddr, d->vaddr + d->size, d->size, d->page_vaddr);
+            d = d->next;
+        }
+    }
+    mpfOsUnlockMutex(table->mutex);
+}

--- a/BBB_cci_mpf/sw/src/libmpf/shim_vtp_buffers.h
+++ b/BBB_cci_mpf/sw/src/libmpf/shim_vtp_buffers.h
@@ -1,0 +1,138 @@
+//
+// Copyright (c) 2023, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// Neither the name of the Intel Corporation nor the names of its contributors
+// may be used to endorse or promote products derived from this software
+// without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * \file shim_vtp_buffers.h
+ * \brief Track buffer start addresses and sizes to support freeing them.
+ */
+
+#ifndef __FPGA_MPF_SHIM_VTP_BUFFERS_H__
+#define __FPGA_MPF_SHIM_VTP_BUFFERS_H__
+
+/**
+ * Descriptor for a single buffer.
+ */
+typedef struct mpf_vtp_buffer_desc *mpf_vtp_buffer_desc_p;
+
+struct mpf_vtp_buffer_desc
+{
+    void* vaddr;
+    size_t size;
+    void* page_vaddr;
+    
+    // Linked list for hash table
+    mpf_vtp_buffer_desc_p next;
+};
+
+
+/**
+ * Hash table, indexed by start address.
+ */
+#define MPF_VTP_BUFFERS_TABLE_SIZE 1021
+
+typedef struct
+{
+    mpf_vtp_buffer_desc_p buckets[MPF_VTP_BUFFERS_TABLE_SIZE];
+
+    // mutex (one update at a time)
+    mpf_os_mutex_handle mutex;
+}
+mpf_vtp_buffer_hash_table;
+
+
+/**
+ * Allocate a buffer table.
+ *
+ * Called internally from VTP.
+ *
+ * @param[in]  _mpf_handle Internal handle to MPF state.
+ * @returns                FPGA_OK on success.
+ */
+fpga_result mpfVtpBuffersInit(
+    _mpf_handle_p _mpf_handle
+);
+
+
+/**
+ * Release the buffer table.
+ *
+ * Called internally from VTP.
+ *
+ * @param[in]  _mpf_handle Internal handle to MPF state.
+ * @returns                FPGA_OK on success.
+ */
+fpga_result mpfVtpBuffersTerm(
+    _mpf_handle_p _mpf_handle
+);
+
+
+/**
+ * Track a new buffer.
+ *
+ * @param[in]  _mpf_handle Internal handle to MPF state.
+ * @param[in]  vaddr       Buffer start virtual address.
+ * @param[in]  size        Buffer size (bytes).
+ * @param[in]  page_vaddr  Page address containing the buffer start.
+ * @returns                FPGA_OK on success.
+ */
+fpga_result mpfVtpBuffersInsert(
+    _mpf_handle_p _mpf_handle,
+    void* vaddr,
+    size_t size,
+    void* page_vaddr
+);
+
+
+/**
+ * Remove a tracked buffer and return its size.
+ *
+ * @param[in]  _mpf_handle Internal handle to MPF state.
+ * @param[in]  vaddr       Buffer start virtual address.
+ * @param[out] page_vaddr  Page address containing the buffer start.
+ *                         (Ignored if NULL.)
+ * @returns                Buffer size. Zero when address not found.
+ */
+size_t mpfVtpBuffersRemove(
+    _mpf_handle_p _mpf_handle,
+    void* vaddr,
+    void** page_vaddr
+);
+
+
+/**
+ * Dump the buffer table.
+ *
+ * @param[in]  _mpf_handle Internal handle to MPF state.
+ */
+void mpfVtpDumpBuffers(
+    _mpf_handle_p _mpf_handle
+);
+
+#endif // __FPGA_MPF_SHIM_VTP_BUFFERS_H__

--- a/BBB_cci_mpf/sw/src/libmpf/shim_vtp_internal.h
+++ b/BBB_cci_mpf/sw/src/libmpf/shim_vtp_internal.h
@@ -38,6 +38,7 @@
 #endif
 
 #include "shim_vtp_pt.h"
+#include "shim_vtp_buffers.h"
 #include "shim_vtp_srv.h"
 #include "shim_vtp_monitor.h"
 
@@ -170,6 +171,9 @@ typedef struct
 
     // VTP munmap event monitor state
     mpf_vtp_monitor* munmap_monitor;
+
+    // User buffer address tracking table
+    mpf_vtp_buffer_hash_table* user_buffers;
 
     // Maximum requested page size
     mpf_vtp_page_size max_physical_page_size;

--- a/BBB_cci_mpf/sw/src/libmpf/shim_vtp_pt.h
+++ b/BBB_cci_mpf/sw/src/libmpf/shim_vtp_pt.h
@@ -97,7 +97,7 @@ typedef void* mpf_vtp_pt_vaddr;
 typedef struct
 {
     uint64_t wsid;
-    size_t alloc_buf_len;
+    uint64_t refcnt;
 }
 mpf_vtp_pt_meta;
 
@@ -250,44 +250,6 @@ fpga_result mpfVtpPtClearInUseFlag(
 
 
 /**
- * Set the size of a buffer associated with a page table entry. The page
- * table is a convenient place to store meta-data describing buffers
- * allocated by mpfVtpPrepareBuffer(). There must already be a page
- * table entry for the VA and either MPF_VTP_PT_FLAG_ALLOC or
- * MPF_VTP_PT_FLAG_PREALLOC must be set for that entry.
- *
- * @param[in]  pt          Page table.
- * @param[in]  va          Virtual address of the buffer start.
- * @param[in]  buf_size    Size of the buffer. The size may span multiple
- *                         pages.
- * @returns                FPGA_OK on success.
- */
-fpga_result mpfVtpPtSetAllocBufSize(
-    mpf_vtp_pt* pt,
-    mpf_vtp_pt_vaddr va,
-    size_t buf_size
-);
-
-
-/**
- * Get the size of an MPF-allocated buffer (set with mpfVtpPtSetAllocBufSize).
- *
- * @param[in]  pt          Page table.
- * @param[in]  va          Virtual address of the buffer start.
- * @param[out] start_va    Starting VA of the buffer, aligned to page size.
- * @param[out] buf_size    Size of the buffer. The size may span multiple
- *                         pages.
- * @returns                FPGA_OK on success.
- */
-fpga_result mpfVtpPtGetAllocBufSize(
-    mpf_vtp_pt* pt,
-    mpf_vtp_pt_vaddr va,
-    mpf_vtp_pt_vaddr* start_va,
-    size_t* buf_size
-);
-
-
-/**
  * Remove a page from the table.
  *
  * Some state from the page is returned as it is dropped.
@@ -336,6 +298,8 @@ fpga_result mpfVtpPtReleaseRange(
  * @param[in]  set_in_use  Set the MPF_VTP_PT_FLAG_IN_USE in the page table
  *                         indicating that the translation has been sent
  *                         to the FPGA.
+ * @param[out] start_va    Starting VA of the page, aligned to page size.
+ *                         (Ignored if NULL.)
  * @param[out] pa          PA corresponding to VA.
  * @param[out] size        Physical page size. Even on failed translations,
  *                         size indicates the level in the page table at
@@ -352,6 +316,7 @@ fpga_result mpfVtpPtTranslateVAtoPA(
     mpf_vtp_pt* pt,
     mpf_vtp_pt_vaddr va,
     bool set_in_use,
+    mpf_vtp_pt_vaddr* start_va,
     mpf_vtp_pt_paddr *pa,
     mpf_vtp_page_size *size,
     uint32_t *flags

--- a/BBB_cci_mpf/test/test-mpf/test_sw/.gitignore
+++ b/BBB_cci_mpf/test/test-mpf/test_sw/.gitignore
@@ -1,2 +1,3 @@
 test_vtp_sw
+test_vtp_refcnt
 obj

--- a/BBB_cci_mpf/test/test-mpf/test_sw/Makefile
+++ b/BBB_cci_mpf/test/test-mpf/test_sw/Makefile
@@ -1,7 +1,7 @@
 include common_include.mk
 
 # Primary test name
-TEST = test_vtp_sw
+TESTS = test_vtp_sw test_vtp_refcnt
 
 # Build directory
 OBJDIR = obj
@@ -9,19 +9,19 @@ CFLAGS += -I./$(OBJDIR)
 CPPFLAGS += -I./$(OBJDIR)
 
 # Files and folders
-SRCS = $(TEST).c
+SRCS = $(addsuffix .c,$(TESTS))
 OBJS = $(addprefix $(OBJDIR)/,$(patsubst %.c,%.o,$(SRCS)))
 
-all: $(TEST)
+all: $(TESTS)
 
-$(TEST): $(OBJS)
-	$(CC) -o $@ $^ $(LDFLAGS) $(FPGA_LIBS) -lMPF
+$(TESTS): $(OBJS)
+	$(CC) -o $@ $(OBJDIR)/$@.o $(LDFLAGS) $(FPGA_LIBS) -lMPF
 
 $(OBJDIR)/%.o: %.c | objdir
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
-	rm -rf $(TEST) $(OBJDIR)
+	rm -rf $(TESTS) $(OBJDIR)
 
 objdir:
 	@mkdir -p $(OBJDIR)


### PR DESCRIPTION
In order to deal with complex patterns of preallocated buffers, VTP
now tracks user buffer ranges outside the page table. When buffers
overlap on physical pages, reference counts keep pages pinned until
the last reference is removed.

Remove all buffer alignment restrictions for preallocated VTP
buffers. Pass a buffer's true start address to mpfVtpPrepareBuffer()
and mpfVtpReleaseBuffer().