### PR TITLE
Resolve Coverity case 3681481 (Resource leak)

### DIFF
--- a/BBB_cci_mpf/test/test-mpf/test_sw/test_vtp_refcnt.c
+++ b/BBB_cci_mpf/test/test-mpf/test_sw/test_vtp_refcnt.c
@@ -129,6 +129,7 @@ static fpga_result buffer_allocate(void **addr, uint64_t len, int flags)
     if (*addr && (*addr != addr_local))
     {
         fprintf(stderr, "Failed to remap at target address %p\n", *addr);
+        munmap(addr_local, len);
         return FPGA_INVALID_PARAM;
     }
 


### PR DESCRIPTION
Fix issue where memory is not unmapped if it is not mapped to the intended address.